### PR TITLE
Phase 0: Add IPC test harness PD (#27)

### DIFF
--- a/kernel/agentos-root-task/Makefile
+++ b/kernel/agentos-root-task/Makefile
@@ -118,6 +118,7 @@ PD_PFLOCAL_SERVER_SRCS   := src/pflocal_server.c src/m3_bare_metal.c src/log.c
 PD_EXEC_SERVER_SRCS      := src/exec_server.c src/m3_bare_metal.c src/log.c
 PD_TERM_SERVER_SRCS      := src/term_server.c src/m3_bare_metal.c src/log.c
 PD_CONSOLESHELL_SRCS     := src/console_shell.c src/m3_bare_metal.c src/log.c
+PD_IPCTEST_SRCS          := src/ipc_harness.c src/m3_bare_metal.c src/log.c
 
 # wasm3 vendored sources (core interpreter only)
 WASM3_SRCS := wasm3/m3_core.c wasm3/m3_env.c wasm3/m3_code.c wasm3/m3_compile.c \
@@ -159,8 +160,16 @@ EXEC_SERVER_OBJS      := $(patsubst src/%.c, $(BUILD_DIR)/%.o, $(PD_EXEC_SERVER_
 TERM_SERVER_OBJS      := $(patsubst src/%.c, $(BUILD_DIR)/%.o, $(PD_TERM_SERVER_SRCS))
 WASM3_OBJS            := $(patsubst wasm3/%.c, $(BUILD_DIR)/wasm3_%.o, $(WASM3_SRCS))
 CONSOLESHELL_OBJS     := $(patsubst src/%.c, $(BUILD_DIR)/%.o, $(PD_CONSOLESHELL_SRCS))
+IPCTEST_OBJS          := $(patsubst src/%.c, $(BUILD_DIR)/%.o, $(PD_IPCTEST_SRCS))
 
-IMAGES := controller.elf event_bus.elf init_agent.elf worker.elf agentfs.elf vibe_engine.elf log_drain.elf swap_slot.elf mem_profiler.elf net_isolator.elf perf_counters.elf time_partition.elf trace_recorder.elf nameserver.elf virtio_blk.elf vfs_server.elf spawn_server.elf app_slot.elf net_server.elf js_runtime.elf wg_net.elf app_manager.elf http_svc.elf vm_manager.elf auth_server.elf ext2fs.elf proc_server.elf vm_snapshot.elf pflocal_server.elf exec_server.elf term_server.elf console_shell.elf
+IMAGES := controller.elf event_bus.elf init_agent.elf worker.elf agentfs.elf vibe_engine.elf log_drain.elf swap_slot.elf mem_profiler.elf net_isolator.elf perf_counters.elf time_partition.elf trace_recorder.elf nameserver.elf virtio_blk.elf vfs_server.elf spawn_server.elf app_slot.elf net_server.elf js_runtime.elf wg_net.elf app_manager.elf http_svc.elf vm_manager.elf auth_server.elf ext2fs.elf proc_server.elf vm_snapshot.elf pflocal_server.elf exec_server.elf term_server.elf console_shell.elf ipc_harness.elf
+
+# IPC test harness — always built; full test sequence enabled with CONFIG_IPC_HARNESS=1
+CONFIG_IPC_HARNESS ?= 0
+CFLAGS_IPCTEST     := $(CFLAGS)
+ifeq ($(CONFIG_IPC_HARNESS),1)
+  CFLAGS_IPCTEST += -DCONFIG_IPC_HARNESS=1
+endif
 
 # Optional: periodic WASM slot snapshot scheduler
 ifdef AGENTOS_SNAPSHOT_SCHED
@@ -344,6 +353,9 @@ $(BUILD_DIR)/console_shell.o: src/console_shell.c
 	$(CC) -c $(CFLAGS_CONSOLESHELL) $< -o $@
 
 $(BUILD_DIR)/console_shell.elf: $(CONSOLESHELL_OBJS)
+	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
+
+$(BUILD_DIR)/ipc_harness.elf: $(IPCTEST_OBJS)
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
 
 # ─── Linux VMM (AArch64 only) ─────────────────────────────────────────────

--- a/kernel/agentos-root-task/src/ipc_harness.c
+++ b/kernel/agentos-root-task/src/ipc_harness.c
@@ -1,0 +1,164 @@
+/*
+ * ipc_harness.c — agentOS IPC Test Harness Protection Domain
+ *
+ * Programmatic IPC test PD. Conditionally compiled when CONFIG_IPC_HARNESS=1.
+ * On init(), executes a static sequence of IPC calls against known PDs and
+ * reports results via the log drain. The PD then goes idle and relies on
+ * Microkit notified()/protected() to stay alive.
+ *
+ * IPC channels (from ipc_harness perspective):
+ *   IPC_HARNESS_CH_EVENTBUS  (0) — PPCs into event_bus: MSG_EVENTBUS_STATUS
+ *   IPC_HARNESS_CH_INITAGENT (1) — PPCs into init_agent: MSG_INITAGENT_STATUS
+ *   IPC_HARNESS_CH_WATCHDOG  (2) — PPCs into watchdog_pd: OP_WD_STATUS
+ *                                  (enabled only when IPC_HARNESS_HAS_WATCHDOG is set)
+ *   CH_LOG_DRAIN            (60) — log drain output (log_drain_write)
+ *
+ * Build:
+ *   Default: no-op stub — always built so the system image stays valid.
+ *   Full harness: pass -DCONFIG_IPC_HARNESS=1 (set CONFIG_IPC_HARNESS=1 in make).
+ *   Watchdog test: additionally pass -DIPC_HARNESS_HAS_WATCHDOG when watchdog_pd
+ *                  is present in the system description.
+ */
+
+#define AGENTOS_DEBUG 1
+#include "agentos.h"
+#include <stdint.h>
+#include <stddef.h>
+
+/*
+ * log_drain_rings_vaddr — seL4cp setvar bound to log_drain_rings mapping.
+ * Declared extern in agentos.h (used by log_drain_write()); defined here so the
+ * Microkit linker can set it via setvar_vaddr="log_drain_rings_vaddr".
+ */
+uintptr_t log_drain_rings_vaddr;
+
+#ifdef CONFIG_IPC_HARNESS
+
+/* ── Logging ──────────────────────────────────────────────────────────────── */
+
+static void ipc_log(const char *msg)
+{
+    log_drain_write(IPC_HARNESS_LOG_SLOT, IPC_HARNESS_PD_ID, msg);
+}
+
+/* Write a single digit character — used for the N/M summary line. */
+static void ipc_log_digit(int n)
+{
+    char s[2] = { '0' + (char)(n % 10), '\0' };
+    ipc_log(s);
+}
+
+/* ── Individual IPC tests ─────────────────────────────────────────────────── */
+
+/*
+ * Test 1: Send MSG_EVENTBUS_STATUS to event_bus.
+ * A functioning event_bus sets MR0 to a non-error value on reply.
+ */
+static int test_eventbus_status(void)
+{
+    microkit_ppcall(IPC_HARNESS_CH_EVENTBUS,
+                    microkit_msginfo_new(MSG_EVENTBUS_STATUS, 0));
+    uint32_t rc = (uint32_t)microkit_mr_get(0);
+    int pass = (rc != 0xDEAD);
+    ipc_log(pass ? "[ipc_harness] PASS: eventbus STATUS\n"
+                 : "[ipc_harness] FAIL: eventbus STATUS (no handler)\n");
+    return pass;
+}
+
+/*
+ * Test 2: Send MSG_INITAGENT_STATUS to init_agent.
+ * A functioning init_agent sets MR0 to a non-error value on reply.
+ */
+static int test_initagent_status(void)
+{
+    microkit_ppcall(IPC_HARNESS_CH_INITAGENT,
+                    microkit_msginfo_new(MSG_INITAGENT_STATUS, 0));
+    uint32_t rc = (uint32_t)microkit_mr_get(0);
+    int pass = (rc != 0xDEAD);
+    ipc_log(pass ? "[ipc_harness] PASS: init_agent STATUS\n"
+                 : "[ipc_harness] FAIL: init_agent STATUS (no handler)\n");
+    return pass;
+}
+
+#ifdef IPC_HARNESS_HAS_WATCHDOG
+/*
+ * Test 3: Send OP_WD_STATUS to watchdog_pd with slot_id=0.
+ * Expects WD_OK (0x00) or WD_ERR_NOENT (0x01) in MR0.
+ * Requires IPC_HARNESS_CH_WATCHDOG wired in the .system file.
+ */
+static int test_watchdog_status(void)
+{
+    microkit_mr_set(0, OP_WD_STATUS);
+    microkit_mr_set(1, 0);   /* slot_id = 0 */
+    microkit_ppcall(IPC_HARNESS_CH_WATCHDOG,
+                    microkit_msginfo_new(OP_WD_STATUS, 2));
+    uint32_t rc = (uint32_t)microkit_mr_get(0);
+    int pass = (rc == WD_OK || rc == WD_ERR_NOENT);
+    ipc_log(pass ? "[ipc_harness] PASS: watchdog STATUS\n"
+                 : "[ipc_harness] FAIL: watchdog STATUS (unexpected reply)\n");
+    return pass;
+}
+#endif /* IPC_HARNESS_HAS_WATCHDOG */
+
+/* ── Summary reporter ─────────────────────────────────────────────────────── */
+
+static void log_summary(int pass, int total)
+{
+    ipc_log("[ipc_harness] SUMMARY: ");
+    ipc_log_digit(pass);
+    ipc_log("/");
+    ipc_log_digit(total);
+    ipc_log(" tests passed\n");
+}
+
+/* ── Microkit entry points ────────────────────────────────────────────────── */
+
+void init(void)
+{
+    ipc_log("[ipc_harness] PD online — running IPC test sequence\n");
+
+    int pass = 0, total = 0;
+
+    total++; pass += test_eventbus_status();
+    total++; pass += test_initagent_status();
+#ifdef IPC_HARNESS_HAS_WATCHDOG
+    total++; pass += test_watchdog_status();
+#endif
+
+    log_summary(pass, total);
+    ipc_log("[ipc_harness] idle\n");
+}
+
+void notified(microkit_channel ch)
+{
+    (void)ch;
+    ipc_log("[ipc_harness] WARN: unexpected notified — PD is idle\n");
+}
+
+microkit_msginfo_t protected(microkit_channel ch, microkit_msginfo_t msginfo)
+{
+    (void)ch; (void)msginfo;
+    ipc_log("[ipc_harness] WARN: unexpected protected — PD is idle\n");
+    microkit_mr_set(0, 0xDEAD);
+    return microkit_msginfo_new(0, 1);
+}
+
+#else /* !CONFIG_IPC_HARNESS */
+
+/* ── Stub: no-op when CONFIG_IPC_HARNESS is not set ──────────────────────── */
+
+void init(void)
+{
+    microkit_dbg_puts("[ipc_harness] disabled (build with CONFIG_IPC_HARNESS=1)\n");
+}
+
+void notified(microkit_channel ch) { (void)ch; }
+
+microkit_msginfo_t protected(microkit_channel ch, microkit_msginfo_t msginfo)
+{
+    (void)ch; (void)msginfo;
+    microkit_mr_set(0, 0xDEAD);
+    return microkit_msginfo_new(0, 1);
+}
+
+#endif /* CONFIG_IPC_HARNESS */


### PR DESCRIPTION
Adds ipc_harness.c — a programmatic IPC test protection domain that validates inter-PD communication at boot.

**Depends on:** PR #45 (phase0/26-log-drain, #26 log_drain rename)

Changes:
- ipc_harness.c (164 lines): conditional stub/full-harness via CONFIG_IPC_HARNESS
- Tests: eventbus STATUS, init_agent STATUS, optional watchdog STATUS
- Uses log_drain_write() for output (depends on #26 log_drain rename)
- Makefile: added PD_IPCTEST_SRCS, IPCTEST_OBJS, ipc_harness.elf target
- CONFIG_IPC_HARNESS=0 default (no-op stub), =1 for full test sequence

Closes #27