### PR TITLE
Add agentos_vendor_fault hook for guest fault extensions

### DIFF
--- a/kernel/agentos-root-task/include/agentos.h
+++ b/kernel/agentos-root-task/include/agentos.h
@@ -644,6 +644,24 @@ void agentos_log_channel(const char *pd, uint32_t ch);
 void agentos_log_fault(const char *pd, agentos_fault_t *f);
 
 /*
+ * agentos_vendor_fault — vendor extension hook for guest faults libvmm
+ * does not recognise. Called by linux_vmm and freebsd_vmm after
+ * libvmm's fault_handle() returns false.
+ *
+ * Default implementation (weak symbol in linux_vmm.c) returns false so
+ * the stock build behaves identically. Distros that extend agentOS —
+ * e.g. SSI cluster work that needs guest -> cluster RPC over a
+ * vendor-defined HVC immediate — override this symbol in their own
+ * translation unit and dispatch to a vendor PD via PPC.
+ *
+ * Returning true means "fault is fully handled, no further action".
+ * Returning false falls through to the existing UART MMIO compliance
+ * stub (linux_vmm) or the LOG_VMM_ERR "unhandled fault" path
+ * (freebsd_vmm).
+ */
+bool agentos_vendor_fault(seL4_Word badge, seL4_MessageInfo_t msginfo);
+
+/*
  * Capability descriptor (simplified for C layer)
  * Full capability management is in the Rust SDK.
  */

--- a/kernel/agentos-root-task/src/freebsd_vmm.c
+++ b/kernel/agentos-root-task/src/freebsd_vmm.c
@@ -686,6 +686,13 @@ static seL4_MessageInfo_t freebsd_vmm_fault(seL4_Word badge,
     bool success = (label == seL4_Fault_VPPIEvent)
         ? freebsd_handle_vppi_event(vcpu_id)
         : fault_handle(vcpu_id, msginfo);
+    if (!success) {
+        /* libvmm did not recognise the fault. Give a vendor extension
+         * a chance before logging it as unhandled. The hook is the
+         * same weak symbol shared with linux_vmm.c so a single
+         * vendor implementation covers both VMMs. */
+        success = agentos_vendor_fault(badge, msginfo);
+    }
     if (!success)
         LOG_VMM_ERR("Unhandled fault: badge=0x%lx label=0x%lx\n",
                     (unsigned long)badge, (unsigned long)label);

--- a/kernel/agentos-root-task/src/linux_vmm.c
+++ b/kernel/agentos-root-task/src/linux_vmm.c
@@ -1424,6 +1424,33 @@ static void linux_vmm_notified(seL4_Word badge)
  *   dropped until the full proxy is wired.  The guest still boots because
  *   early serial writes do not require a response.
  */
+/*
+ * agentos_vendor_fault — vendor extension hook for guest faults libvmm
+ * doesn't recognise.
+ *
+ * libvmm's fault_handle() handles standard ARMv8 VM faults (MMIO, VPPI,
+ * legacy SBI/HVC subset). Anything outside that surface — vendor-defined
+ * HVC immediates, SBI extension EIDs in the vendor-reserved range,
+ * platform-specific traps — falls through to here.
+ *
+ * Default implementation (this file, weak symbol) returns false so the
+ * stock build behaves identically to before this commit. Distros that
+ * extend agentOS (e.g. SSI cluster work that needs guest -> cluster RPC)
+ * override this symbol in their own translation unit and dispatch to a
+ * vendor PD via PPC.
+ *
+ * Returning true means "this fault is fully handled, nothing else to
+ * do". Returning false falls through to the existing UART MMIO
+ * compliance stub.
+ */
+__attribute__((weak))
+bool agentos_vendor_fault(seL4_Word badge, seL4_MessageInfo_t msginfo)
+{
+    (void)badge;
+    (void)msginfo;
+    return false;
+}
+
 static seL4_MessageInfo_t linux_vmm_fault(seL4_Word badge,
                                           seL4_MessageInfo_t msginfo)
 {
@@ -1431,6 +1458,12 @@ static seL4_MessageInfo_t linux_vmm_fault(seL4_Word badge,
      * Strip the upper flag bits to recover the raw vcpu_id. */
     size_t vcpu_id = badge & ~VMM_FAULT_BADGE_FLAG;
     bool success = fault_handle(vcpu_id, msginfo);
+    if (!success) {
+        /* libvmm did not recognise the fault. Give a vendor extension
+         * a chance to handle it before falling through to the UART
+         * MMIO compliance stub. */
+        success = agentos_vendor_fault(badge, msginfo);
+    }
     (void)success;
     /* UART MMIO fault compliance stub — silently accept, guest continues. */
     return seL4_MessageInfo_new(0, 0, 0, 0);


### PR DESCRIPTION
## What

A single weak-symbol hook in the linux_vmm / freebsd_vmm fault path:

```c
bool agentos_vendor_fault(seL4_Word badge, seL4_MessageInfo_t info);
```

Both VMMs call it after libvmm's `fault_handle()` returns false, giving a downstream PD a chance to handle the fault before it falls through to the existing UART MMIO compliance stub (linux_vmm) or the `LOG_VMM_ERR` path (freebsd_vmm).

+58 lines across 3 files. Default behaviour is unchanged: the weak symbol returns false, every existing build path runs exactly as before.

## Why

Vendor-defined HVC immediates and SBI extension EIDs in the vendor-reserved range trap as `seL4_Fault_UnknownSyscall`, which libvmm's `fault_handle()` doesn't recognise. With this hook a downstream extension can dispatch them via PPC into a vendor PD without forking `linux_vmm.c`/`freebsd_vmm.c`.

## Use case

The HydraOS SSI cluster work ([lesserevil/hydraos](https://github.com/lesserevil/hydraos)) needs to bridge `fork`/`exec` calls from inside a Linux guest into a `cluster_spawn_pd` that routes them across a cluster of HydraOS nodes. The guest kernel module (`hydra_bridge.ko`) issues an HVC with HydraOS extension EID `0x48594452` ("HYDR"). With this hook HydraOS can override `agentos_vendor_fault` and dispatch the HVC to its PD; without it, the only option is forking the VMM source.

## Why "draft"

I haven't yet wired the consumer side end-to-end on HydraOS — `cluster_spawn_pd` exists and is bundled, but the override of `agentos_vendor_fault` calling into it is the next step. Filing now to gather design feedback before sinking that work.

Open to:
- A registration table instead of a single weak symbol if multiple vendors want to chain.
- A reserved EID/imm range called out in `agentos.h` so vendors don't collide.
- A naming convention other than `agentos_vendor_fault`.

## Tested

- `make build` (aarch64) clean: 134 MB image, 39 PDs.
- No behaviour change observed in stock build paths.
