### PR TITLE
platform: read-only inspect snapshot for operator sessions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -637,6 +637,16 @@ test-integration:
 	    echo "FAIL: tests/platform/test_net_virt_pump.c"; \
 	    status=1; \
 	fi; \
+	if gcc -I platform/include \
+	        tests/platform/test_inspect_snapshot.c \
+	        platform/inspect/inspect_snapshot.c \
+	        -o $(BUILD_TMP_DIR)/test_inspect_snapshot 2>&1 \
+	    && $(BUILD_TMP_DIR)/test_inspect_snapshot; then \
+	    echo "PASS: tests/platform/test_inspect_snapshot.c"; \
+	else \
+	    echo "FAIL: tests/platform/test_inspect_snapshot.c"; \
+	    status=1; \
+	fi; \
 	echo ""; \
 	echo "Integration tests complete."; \
 	echo ""; \

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,7 +1,7 @@
 # agentOS — Platform Plan
 
 **Status:** Active  
-**Last updated:** 2026-09-02  
+**Last updated:** 2026-09-03  
 **Epic:** mac `task_a2c5cdc55f994af8bc9fc48b13c54d5a` (project `agentos`)
 
 QEMU is a hardware emulator so we can prototype quickly. agentOS is the
@@ -40,6 +40,23 @@ packets. Then it must assert I/O through `net_virt`, not QEMU bus ownership.
 Host tests for `aos_net_virt_pump` are a pre-filter. They are not proof that
 the guest sees the device. That proof is
 `task_0d44a94246554eeabc8d5bc8e36ab6d7`.
+
+## Operator session (parallel; not I/O proof)
+
+Hermes-on-agentOS is a **client** of inspect + later `serial_virt`, not a PD
+and not `term_server`. Start with a read-only snapshot of memory, threads,
+and hardware (`platform/include/platform/inspect.h`). Host tests are a
+pre-filter. They are not a live seL4 query.
+
+| Step | mac task | Status | Work |
+|------|----------|--------|------|
+| A | `task_72e781c303084d638b732e48d0e9132d` | open | Epic: inspect, then Hermes client |
+| A1 | `task_a80ae509b10540c7932b03d95df2e74b` | open | Packed inspect snapshot + structured report |
+| A2 | `task_0981068853cc4881886a6483f1583733` | waiting on A1 | Line protocol on `serial_virt` |
+| A3 | `task_1ab2cbb61c374bd99b43bbfbebf05bdc` | waiting on A1 | Guest/external Hermes; user API key; never in-tree |
+
+Session context: `skills/hermes-session/SKILL.md`. Compose/mutate of
+services is out of scope until inspect and serial attach exist.
 
 ## First net vertical slice (step 2)
 

--- a/kernel/agentos-root-task/include/contracts/inspect_contract.h
+++ b/kernel/agentos-root-task/include/contracts/inspect_contract.h
@@ -1,0 +1,43 @@
+/*
+ * Inspect IPC contract (read-only)
+ *
+ * Packed snapshot of memory, threads (PDs), and hardware attributes.
+ * The live ABI and host tests live in platform/include/platform/inspect.h.
+ * This header is the future seL4 IPC view of the same structs.
+ *
+ * No PD implements this yet. Do not add MSG_* opcodes to agentos.h until
+ * an inspect reporter exists. That reporter is not TCB: no device frames,
+ * no IRQs. term_server is museum — session I/O is serial_virt, not this
+ * contract.
+ *
+ * Opcodes (local until a PD is registered):
+ *   AOS_INSPECT_OP_SNAPSHOT  full snapshot
+ *   AOS_INSPECT_OP_MEMORY    memory subsection
+ *   AOS_INSPECT_OP_THREADS   thread table
+ *   AOS_INSPECT_OP_HARDWARE  hardware subsection
+ *
+ * Invariants:
+ *   - Read-only. No mutate, compose, or spawn opcodes here.
+ *   - Reply payload is aos_inspect_snapshot_t (platform/inspect.h).
+ *   - version must be AOS_INSPECT_VERSION.
+ *   - thread_count <= AOS_INSPECT_MAX_THREADS.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#define AOS_INSPECT_OP_SNAPSHOT   1u
+#define AOS_INSPECT_OP_MEMORY     2u
+#define AOS_INSPECT_OP_THREADS    3u
+#define AOS_INSPECT_OP_HARDWARE   4u
+
+typedef struct __attribute__((packed)) aos_inspect_req {
+    uint32_t opcode;
+    uint32_t flags;
+} aos_inspect_req_t;
+
+typedef struct __attribute__((packed)) aos_inspect_reply_hdr {
+    uint32_t opcode;
+    int32_t  status;
+} aos_inspect_reply_hdr_t;

--- a/platform/README.md
+++ b/platform/README.md
@@ -9,6 +9,8 @@ QEMU virtio-mmio. Native agents attach to the same virtualizers as a VMM.
 | Path | Role |
 |------|------|
 | `include/platform/net_layout.h` | sDDF-shaped net queue ABI (no seL4) |
+| `include/platform/inspect.h` | Read-only memory/thread/hardware snapshot (no seL4) |
+| `inspect/inspect_snapshot.c` | Fill + `key=value` report (host-testable) |
 | `net-virt/net_virt_pump.c` | Hub / loopback (host-testable) |
 | `net-virt/vmm_virtio_net.c` | libvmm `virtio_mmio_net_init` + after-fault pump |
 | `net-virt/net_virt.c` | Future `net_virt` PD — **not in the live image** |

--- a/platform/include/platform/inspect.h
+++ b/platform/include/platform/inspect.h
@@ -1,0 +1,97 @@
+/*
+ * agentOS inspect snapshot ABI
+ *
+ * Read-only view of memory, threads (protection domains), and hardware
+ * attributes. Host-testable: no seL4 headers. A later inspect PD copies
+ * the same packed structs over IPC; it does not own device frames or IRQs.
+ *
+ * This is not a UI. The formatter emits structured key=value lines for a
+ * client (guest Hermes, or any serial_virt consumer).
+ */
+
+#ifndef AOS_PLATFORM_INSPECT_H
+#define AOS_PLATFORM_INSPECT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define AOS_INSPECT_VERSION            1u
+#define AOS_INSPECT_MAX_THREADS        32u
+#define AOS_INSPECT_NAME_LEN           32u
+
+#define AOS_INSPECT_ARCH_UNKNOWN       0u
+#define AOS_INSPECT_ARCH_AARCH64       1u
+#define AOS_INSPECT_ARCH_X86_64        2u
+#define AOS_INSPECT_ARCH_RISCV64       3u
+
+#define AOS_INSPECT_THR_UNKNOWN        0u
+#define AOS_INSPECT_THR_RUNNING        1u
+#define AOS_INSPECT_THR_BLOCKED        2u
+#define AOS_INSPECT_THR_IDLE           3u
+
+#define AOS_INSPECT_FLAG_PARTIAL       1u
+
+#define AOS_INSPECT_OK                 0
+#define AOS_INSPECT_ERR_NULL          (-1)
+#define AOS_INSPECT_ERR_VERSION       (-2)
+#define AOS_INSPECT_ERR_TRUNC         (-3)
+#define AOS_INSPECT_ERR_TOO_MANY      (-4)
+#define AOS_INSPECT_ERR_NOT_FOUND     (-5)
+
+typedef struct __attribute__((packed)) aos_inspect_memory {
+    uint64_t ut_total_bytes;
+    uint64_t ut_used_bytes;
+    uint64_t guest_ram_bytes;
+    uint32_t pd_count;
+    uint32_t reserved;
+} aos_inspect_memory_t;
+
+typedef struct __attribute__((packed)) aos_inspect_hardware {
+    uint32_t arch;
+    uint32_t virtio_net_virq;
+    uint64_t uart_pa;
+    uint64_t gic_dist_pa;
+    uint64_t virtio_net_ipa;
+} aos_inspect_hardware_t;
+
+typedef struct __attribute__((packed)) aos_inspect_thread {
+    uint32_t pd_index;
+    uint32_t prio;
+    uint32_t state;
+    uint8_t  name[AOS_INSPECT_NAME_LEN];
+} aos_inspect_thread_t;
+
+typedef struct __attribute__((packed)) aos_inspect_snapshot {
+    uint32_t version;
+    uint32_t flags;
+    aos_inspect_memory_t mem;
+    aos_inspect_hardware_t hw;
+    uint32_t thread_count;
+    uint32_t reserved;
+    aos_inspect_thread_t threads[AOS_INSPECT_MAX_THREADS];
+} aos_inspect_snapshot_t;
+
+/*
+ * Observation injected by the root task (or a host test). Not a live seL4
+ * query — the filler only copies and validates.
+ */
+typedef struct aos_inspect_view {
+    uint64_t ut_total_bytes;
+    uint64_t ut_used_bytes;
+    uint64_t guest_ram_bytes;
+    uint32_t arch;
+    uint32_t virtio_net_virq;
+    uint64_t uart_pa;
+    uint64_t gic_dist_pa;
+    uint64_t virtio_net_ipa;
+    uint32_t thread_count;
+    aos_inspect_thread_t threads[AOS_INSPECT_MAX_THREADS];
+} aos_inspect_view_t;
+
+int aos_inspect_fill(aos_inspect_snapshot_t *snap, const aos_inspect_view_t *view);
+int aos_inspect_format(const aos_inspect_snapshot_t *snap, char *buf, size_t buflen);
+int aos_inspect_thread_by_name(const aos_inspect_snapshot_t *snap,
+                               const char *name,
+                               const aos_inspect_thread_t **out);
+
+#endif /* AOS_PLATFORM_INSPECT_H */

--- a/platform/inspect/inspect_snapshot.c
+++ b/platform/inspect/inspect_snapshot.c
@@ -1,0 +1,314 @@
+/*
+ * Fill and format an inspect snapshot. No seL4. No libc I/O.
+ */
+
+#include <platform/inspect.h>
+
+#include <stddef.h>
+#include <string.h>
+
+static void copy_name(uint8_t dst[AOS_INSPECT_NAME_LEN], const uint8_t src[AOS_INSPECT_NAME_LEN])
+{
+    uint32_t i;
+    uint32_t saw_nul = 0u;
+
+    for (i = 0u; i < AOS_INSPECT_NAME_LEN; i++) {
+        if (saw_nul) {
+            dst[i] = 0u;
+        } else {
+            dst[i] = src[i];
+            if (src[i] == 0u) {
+                saw_nul = 1u;
+            }
+        }
+    }
+    dst[AOS_INSPECT_NAME_LEN - 1u] = 0u;
+}
+
+static int names_equal(const uint8_t a[AOS_INSPECT_NAME_LEN], const char *b)
+{
+    uint32_t i;
+
+    if (b == NULL) {
+        return 0;
+    }
+    for (i = 0u; i < AOS_INSPECT_NAME_LEN; i++) {
+        uint8_t ca = a[i];
+        uint8_t cb = (uint8_t)b[i];
+
+        if (ca != cb) {
+            return 0;
+        }
+        if (ca == 0u) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int aos_inspect_fill(aos_inspect_snapshot_t *snap, const aos_inspect_view_t *view)
+{
+    uint32_t i;
+
+    if (snap == NULL || view == NULL) {
+        return AOS_INSPECT_ERR_NULL;
+    }
+    if (view->thread_count > AOS_INSPECT_MAX_THREADS) {
+        return AOS_INSPECT_ERR_TOO_MANY;
+    }
+
+    memset(snap, 0, sizeof(*snap));
+    snap->version = AOS_INSPECT_VERSION;
+    snap->flags = 0u;
+    snap->mem.ut_total_bytes = view->ut_total_bytes;
+    snap->mem.ut_used_bytes = view->ut_used_bytes;
+    snap->mem.guest_ram_bytes = view->guest_ram_bytes;
+    snap->mem.pd_count = view->thread_count;
+    snap->hw.arch = view->arch;
+    snap->hw.virtio_net_virq = view->virtio_net_virq;
+    snap->hw.uart_pa = view->uart_pa;
+    snap->hw.gic_dist_pa = view->gic_dist_pa;
+    snap->hw.virtio_net_ipa = view->virtio_net_ipa;
+    snap->thread_count = view->thread_count;
+
+    for (i = 0u; i < view->thread_count; i++) {
+        snap->threads[i].pd_index = view->threads[i].pd_index;
+        snap->threads[i].prio = view->threads[i].prio;
+        snap->threads[i].state = view->threads[i].state;
+        copy_name(snap->threads[i].name, view->threads[i].name);
+    }
+
+    if (view->arch == AOS_INSPECT_ARCH_UNKNOWN || view->ut_total_bytes == 0u) {
+        snap->flags |= AOS_INSPECT_FLAG_PARTIAL;
+    }
+
+    return AOS_INSPECT_OK;
+}
+
+int aos_inspect_thread_by_name(const aos_inspect_snapshot_t *snap,
+                               const char *name,
+                               const aos_inspect_thread_t **out)
+{
+    uint32_t i;
+
+    if (snap == NULL || name == NULL || out == NULL) {
+        return AOS_INSPECT_ERR_NULL;
+    }
+    if (snap->version != AOS_INSPECT_VERSION) {
+        return AOS_INSPECT_ERR_VERSION;
+    }
+    for (i = 0u; i < snap->thread_count && i < AOS_INSPECT_MAX_THREADS; i++) {
+        if (names_equal(snap->threads[i].name, name)) {
+            *out = &snap->threads[i];
+            return AOS_INSPECT_OK;
+        }
+    }
+    return AOS_INSPECT_ERR_NOT_FOUND;
+}
+
+static int putc_raw(char **p, char *end, char c)
+{
+    if (*p >= end) {
+        return -1;
+    }
+    **p = c;
+    (*p)++;
+    return 0;
+}
+
+static int puts_raw(char **p, char *end, const char *s)
+{
+    while (*s != '\0') {
+        if (putc_raw(p, end, *s) != 0) {
+            return -1;
+        }
+        s++;
+    }
+    return 0;
+}
+
+static int put_u64(char **p, char *end, uint64_t v)
+{
+    char tmp[20];
+    uint32_t n = 0u;
+    uint32_t i;
+
+    if (v == 0u) {
+        return putc_raw(p, end, '0');
+    }
+    while (v > 0u && n < sizeof(tmp)) {
+        tmp[n++] = (char)('0' + (v % 10u));
+        v /= 10u;
+    }
+    for (i = n; i > 0u; i--) {
+        if (putc_raw(p, end, tmp[i - 1u]) != 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int put_hex64(char **p, char *end, uint64_t v)
+{
+    static const char digits[] = "0123456789abcdef";
+    char tmp[16];
+    uint32_t n = 0u;
+    uint32_t i;
+
+    if (puts_raw(p, end, "0x") != 0) {
+        return -1;
+    }
+    if (v == 0u) {
+        return putc_raw(p, end, '0');
+    }
+    while (v > 0u && n < sizeof(tmp)) {
+        tmp[n++] = digits[v & 0xfu];
+        v >>= 4u;
+    }
+    for (i = n; i > 0u; i--) {
+        if (putc_raw(p, end, tmp[i - 1u]) != 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static const char *arch_name(uint32_t arch)
+{
+    switch (arch) {
+    case AOS_INSPECT_ARCH_AARCH64:
+        return "aarch64";
+    case AOS_INSPECT_ARCH_X86_64:
+        return "x86_64";
+    case AOS_INSPECT_ARCH_RISCV64:
+        return "riscv64";
+    default:
+        return "unknown";
+    }
+}
+
+static const char *thr_state_name(uint32_t state)
+{
+    switch (state) {
+    case AOS_INSPECT_THR_RUNNING:
+        return "running";
+    case AOS_INSPECT_THR_BLOCKED:
+        return "blocked";
+    case AOS_INSPECT_THR_IDLE:
+        return "idle";
+    default:
+        return "unknown";
+    }
+}
+
+static int line_u64(char **p, char *end, const char *key, uint64_t val)
+{
+    if (puts_raw(p, end, key) != 0 || putc_raw(p, end, '=') != 0
+        || put_u64(p, end, val) != 0 || putc_raw(p, end, '\n') != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+static int line_hex(char **p, char *end, const char *key, uint64_t val)
+{
+    if (puts_raw(p, end, key) != 0 || putc_raw(p, end, '=') != 0
+        || put_hex64(p, end, val) != 0 || putc_raw(p, end, '\n') != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+static int line_str(char **p, char *end, const char *key, const char *val)
+{
+    if (puts_raw(p, end, key) != 0 || putc_raw(p, end, '=') != 0
+        || puts_raw(p, end, val) != 0 || putc_raw(p, end, '\n') != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+static int thread_prefix(char *key, size_t keylen, uint32_t idx, const char *field)
+{
+    char *kp = key;
+    char *kend = key + keylen - 1u;
+
+    if (puts_raw(&kp, kend, "thread[") != 0 || put_u64(&kp, kend, idx) != 0
+        || puts_raw(&kp, kend, "].") != 0 || puts_raw(&kp, kend, field) != 0) {
+        return -1;
+    }
+    *kp = '\0';
+    return 0;
+}
+
+int aos_inspect_format(const aos_inspect_snapshot_t *snap, char *buf, size_t buflen)
+{
+    char *p;
+    char *end;
+    uint32_t i;
+
+    if (snap == NULL || buf == NULL) {
+        return AOS_INSPECT_ERR_NULL;
+    }
+    if (buflen < 1u) {
+        return AOS_INSPECT_ERR_TRUNC;
+    }
+    if (snap->version != AOS_INSPECT_VERSION) {
+        buf[0] = '\0';
+        return AOS_INSPECT_ERR_VERSION;
+    }
+
+    p = buf;
+    end = buf + buflen - 1u;
+
+    if (line_u64(&p, end, "inspect.version", snap->version) != 0
+        || line_u64(&p, end, "inspect.flags", snap->flags) != 0
+        || line_u64(&p, end, "memory.ut_total_bytes", snap->mem.ut_total_bytes) != 0
+        || line_u64(&p, end, "memory.ut_used_bytes", snap->mem.ut_used_bytes) != 0
+        || line_u64(&p, end, "memory.guest_ram_bytes", snap->mem.guest_ram_bytes) != 0
+        || line_u64(&p, end, "memory.pd_count", snap->mem.pd_count) != 0
+        || line_str(&p, end, "hardware.arch", arch_name(snap->hw.arch)) != 0
+        || line_hex(&p, end, "hardware.uart_pa", snap->hw.uart_pa) != 0
+        || line_hex(&p, end, "hardware.gic_dist_pa", snap->hw.gic_dist_pa) != 0
+        || line_hex(&p, end, "hardware.virtio_net_ipa", snap->hw.virtio_net_ipa) != 0
+        || line_u64(&p, end, "hardware.virtio_net_virq", snap->hw.virtio_net_virq) != 0
+        || line_u64(&p, end, "thread.count", snap->thread_count) != 0) {
+        *p = '\0';
+        return AOS_INSPECT_ERR_TRUNC;
+    }
+
+    for (i = 0u; i < snap->thread_count && i < AOS_INSPECT_MAX_THREADS; i++) {
+        char key[48];
+        const uint8_t *nm = snap->threads[i].name;
+        uint32_t n;
+
+        if (thread_prefix(key, sizeof(key), i, "name") != 0
+            || puts_raw(&p, end, key) != 0 || putc_raw(&p, end, '=') != 0) {
+            *p = '\0';
+            return AOS_INSPECT_ERR_TRUNC;
+        }
+        for (n = 0u; n < AOS_INSPECT_NAME_LEN && nm[n] != 0u; n++) {
+            if (putc_raw(&p, end, (char)nm[n]) != 0) {
+                *p = '\0';
+                return AOS_INSPECT_ERR_TRUNC;
+            }
+        }
+        if (putc_raw(&p, end, '\n') != 0) {
+            *p = '\0';
+            return AOS_INSPECT_ERR_TRUNC;
+        }
+
+        if (thread_prefix(key, sizeof(key), i, "pd_index") != 0
+            || line_u64(&p, end, key, snap->threads[i].pd_index) != 0
+            || thread_prefix(key, sizeof(key), i, "prio") != 0
+            || line_u64(&p, end, key, snap->threads[i].prio) != 0
+            || thread_prefix(key, sizeof(key), i, "state") != 0
+            || line_str(&p, end, key, thr_state_name(snap->threads[i].state)) != 0) {
+            *p = '\0';
+            return AOS_INSPECT_ERR_TRUNC;
+        }
+    }
+
+    *p = '\0';
+    return (int)(p - buf);
+}

--- a/skills/hermes-session/SKILL.md
+++ b/skills/hermes-session/SKILL.md
@@ -1,0 +1,75 @@
+# Hermes operator session (agentOS)
+
+This file is the session context an operator agent (Hermes or any other LLM
+CLI) loads when attached to agentOS. It is not a UI. It is not a PD.
+
+## What agentOS is
+
+agentOS is a capability-secured OS on seL4. Guests (Linux, FreeBSD) and
+native agents consume **virtualizers** (serial, net, blk). seL4 is the only
+kernel-mode code. Native agents are not TCB.
+
+## What this session may do (now)
+
+**Read and report.** Call the inspect snapshot ABI:
+
+- Header: `platform/include/platform/inspect.h`
+- Fill: `aos_inspect_fill`
+- Structured text: `aos_inspect_format` (`key=value` lines)
+
+The snapshot covers:
+
+- **Memory:** untyped pool total/used, guest RAM size, PD count
+- **Threads:** PD index, name, priority, state (running/blocked/idle/unknown)
+- **Hardware:** arch, UART PA, GIC distributor PA, emulated virtio-net IPA/IRQ
+
+Host tests: `tests/platform/test_inspect_snapshot.c` (via `make test-host`).
+Those tests are a pre-filter. They do not prove a live seL4 query.
+
+## What this session must not do
+
+- No HTML/JS/TUI in this repository. Hermes-the-product is a **client**.
+- No JavaScript Protection Domain. No Node in `kernel/`, `services/`, or
+  `userspace/servers/`.
+- Do not extend `term_server`. It is museum. Interactive bytes later ride
+  `serial_virt` (generic serial), same as other native clients.
+- Do not store API keys or provider secrets in this tree. The user supplies
+  them to the client at attach time.
+- Do not compose, spawn, or mutate services in this slice. Inspect is
+  read-only (`AOS_INSPECT_OP_SNAPSHOT` and friends). Compose is a later
+  contract with its own tests.
+- Do not claim host tests as guest-boot or live-IPC proof.
+
+## Architecture (target)
+
+```
+user + API key + provider URL
+        │
+        ▼
+Hermes (or other LLM CLI)     ← guest userspace or external process
+        │  SKILL.md (this file) + inspect report
+        ▼
+serial_virt client (PTY-shaped session is a serial client)
+        │
+        ▼
+inspect snapshot (C structs)  ← filled from root-task observations
+```
+
+Slice order: inspect report (this skill + ABI) → serial_virt line protocol →
+LLM client with user key. Do not skip to compose.
+
+## Hardware facts the report should know
+
+- Emulated virtio-net guest IPA: `0x0A010000` (`AOS_VIRTIO_NET_GUEST_IPA`)
+- That IPA must fault to the VMM. QEMU virtio-mmio at `0x0A000000` is a
+  kill-dated crutch.
+- One UART owner. Guests see virtio-console, not the UART.
+
+## Tracker
+
+mac project `agentos` (dispatch paused — do not activate).
+
+- Epic: `task_72e781c303084d638b732e48d0e9132d`
+- Slice 1 (inspect): `task_a80ae509b10540c7932b03d95df2e74b`
+- Slice 2 (serial_virt session): `task_0981068853cc4881886a6483f1583733`
+- Slice 3 (Hermes client): `task_1ab2cbb61c374bd99b43bbfbebf05bdc`

--- a/tests/platform/test_inspect_snapshot.c
+++ b/tests/platform/test_inspect_snapshot.c
@@ -1,0 +1,137 @@
+/*
+ * Host test for inspect snapshot fill + structured report. No seL4.
+ *
+ * gcc -I platform/include tests/platform/test_inspect_snapshot.c \
+ *     platform/inspect/inspect_snapshot.c -o test_inspect_snapshot
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <platform/inspect.h>
+#include <platform/net_layout.h>
+
+#define PASS(name) do { printf("  PASS  %s\n", name); return 0; } while (0)
+#define FAIL(msg)  do { printf("  FAIL  %s:%d: %s\n", __FILE__, __LINE__, msg); return 1; } while (0)
+#define CHECK(cond) do { if (!(cond)) FAIL(#cond); } while (0)
+
+static void set_name(aos_inspect_thread_t *t, const char *s)
+{
+    size_t n = strlen(s);
+    memset(t->name, 0, AOS_INSPECT_NAME_LEN);
+    if (n >= AOS_INSPECT_NAME_LEN) {
+        n = AOS_INSPECT_NAME_LEN - 1u;
+    }
+    memcpy(t->name, s, n);
+}
+
+static void sample_view(aos_inspect_view_t *v)
+{
+    memset(v, 0, sizeof(*v));
+    v->ut_total_bytes = 1024ull * 1024ull * 1024ull;
+    v->ut_used_bytes = 64ull * 1024ull * 1024ull;
+    v->guest_ram_bytes = 512ull * 1024ull * 1024ull;
+    v->arch = AOS_INSPECT_ARCH_AARCH64;
+    v->virtio_net_virq = AOS_VIRTIO_NET_VIRQ;
+    v->uart_pa = 0x09000000ull;
+    v->gic_dist_pa = 0x08000000ull;
+    v->virtio_net_ipa = AOS_VIRTIO_NET_GUEST_IPA;
+    v->thread_count = 3u;
+    v->threads[0].pd_index = 0u;
+    v->threads[0].prio = 245u;
+    v->threads[0].state = AOS_INSPECT_THR_RUNNING;
+    set_name(&v->threads[0], "nameserver");
+    v->threads[1].pd_index = 1u;
+    v->threads[1].prio = 250u;
+    v->threads[1].state = AOS_INSPECT_THR_BLOCKED;
+    set_name(&v->threads[1], "linux_vmm");
+    v->threads[2].pd_index = 2u;
+    v->threads[2].prio = 225u;
+    v->threads[2].state = AOS_INSPECT_THR_IDLE;
+    set_name(&v->threads[2], "serial_pd");
+}
+
+static int test_abi(void)
+{
+    CHECK(AOS_INSPECT_VERSION == 1u);
+    CHECK(AOS_INSPECT_MAX_THREADS == 32u);
+    CHECK(sizeof(aos_inspect_memory_t) == 32u);
+    CHECK(sizeof(aos_inspect_hardware_t) == 32u);
+    CHECK(sizeof(aos_inspect_thread_t) == 44u);
+    CHECK(AOS_VIRTIO_NET_GUEST_IPA == 0x0A010000UL);
+    PASS("test_abi");
+}
+
+static int test_fill_report(void)
+{
+    aos_inspect_view_t view;
+    aos_inspect_snapshot_t snap;
+    const aos_inspect_thread_t *thr;
+    char buf[2048];
+    int n;
+
+    sample_view(&view);
+    CHECK(aos_inspect_fill(&snap, &view) == AOS_INSPECT_OK);
+    CHECK(snap.version == AOS_INSPECT_VERSION);
+    CHECK((snap.flags & AOS_INSPECT_FLAG_PARTIAL) == 0u);
+    CHECK(snap.mem.ut_total_bytes == view.ut_total_bytes);
+    CHECK(snap.mem.pd_count == 3u);
+    CHECK(snap.hw.virtio_net_ipa == AOS_VIRTIO_NET_GUEST_IPA);
+    CHECK(snap.thread_count == 3u);
+
+    CHECK(aos_inspect_thread_by_name(&snap, "linux_vmm", &thr) == AOS_INSPECT_OK);
+    CHECK(thr->prio == 250u);
+    CHECK(thr->state == AOS_INSPECT_THR_BLOCKED);
+    CHECK(aos_inspect_thread_by_name(&snap, "missing", &thr) == AOS_INSPECT_ERR_NOT_FOUND);
+
+    n = aos_inspect_format(&snap, buf, sizeof(buf));
+    CHECK(n > 0);
+    CHECK(strstr(buf, "inspect.version=1\n") != NULL);
+    CHECK(strstr(buf, "memory.ut_total_bytes=1073741824\n") != NULL);
+    CHECK(strstr(buf, "hardware.arch=aarch64\n") != NULL);
+    CHECK(strstr(buf, "hardware.virtio_net_ipa=0xa010000\n") != NULL);
+    CHECK(strstr(buf, "thread[1].name=linux_vmm\n") != NULL);
+    CHECK(strstr(buf, "thread[1].state=blocked\n") != NULL);
+    CHECK(strstr(buf, "thread[2].name=serial_pd\n") != NULL);
+    PASS("test_fill_report");
+}
+
+static int test_errors(void)
+{
+    aos_inspect_view_t view;
+    aos_inspect_snapshot_t snap;
+    char tiny[8];
+    char buf[64];
+
+    CHECK(aos_inspect_fill(NULL, NULL) == AOS_INSPECT_ERR_NULL);
+
+    sample_view(&view);
+    view.thread_count = AOS_INSPECT_MAX_THREADS + 1u;
+    CHECK(aos_inspect_fill(&snap, &view) == AOS_INSPECT_ERR_TOO_MANY);
+
+    sample_view(&view);
+    view.arch = AOS_INSPECT_ARCH_UNKNOWN;
+    view.ut_total_bytes = 0u;
+    CHECK(aos_inspect_fill(&snap, &view) == AOS_INSPECT_OK);
+    CHECK((snap.flags & AOS_INSPECT_FLAG_PARTIAL) != 0u);
+
+    sample_view(&view);
+    CHECK(aos_inspect_fill(&snap, &view) == AOS_INSPECT_OK);
+    CHECK(aos_inspect_format(&snap, tiny, sizeof(tiny)) == AOS_INSPECT_ERR_TRUNC);
+
+    snap.version = 99u;
+    CHECK(aos_inspect_format(&snap, buf, sizeof(buf)) == AOS_INSPECT_ERR_VERSION);
+    PASS("test_errors");
+}
+
+int main(void)
+{
+    int fails = 0;
+
+    printf("test_inspect_snapshot\n");
+    fails += test_abi();
+    fails += test_fill_report();
+    fails += test_errors();
+    return fails == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Packed inspect ABI for memory, threads (PDs), and hardware, plus a structured `key=value` report.
- Session context in `skills/hermes-session/SKILL.md`. Hermes is a client, not a PD; `term_server` stays museum.
- `PLAN.md` records the operator-session track (inspect → `serial_virt` → user API key).

Merge **first**. Then #105 (net), #104 (GPA), #106 (blk).

Refs: #102

## Test plan
- [x] `make test-host` (includes `tests/platform/test_inspect_snapshot.c`)
- [ ] Live seL4 fill from the root task (follow-up)
- [ ] `serial_virt` line protocol (follow-up)