### PR TITLE
ci: fix WASM example link and Phase 5 guest fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,11 +209,11 @@ jobs:
 
       - name: Build agentOS with IPC harness (CONFIG_IPC_HARNESS=1)
         run: |
-          make build BOARD=qemu_virt_aarch64 CONFIG_IPC_HARNESS=1
+          make build BOARD=qemu_virt_aarch64 CONFIG_IPC_HARNESS=1 GUEST_OS=none
 
       - name: Run contract tests
         run: |
-          make test BOARD=qemu_virt_aarch64
+          make test BOARD=qemu_virt_aarch64 GUEST_OS=none
         timeout-minutes: 5
 
       - name: Upload contract test artifacts

--- a/examples/health-monitor/src/lib.rs
+++ b/examples/health-monitor/src/lib.rs
@@ -1,3 +1,4 @@
+#[link(wasm_import_module = "env")]
 extern "C" {
     fn aos_log(ptr: *const u8, len: usize);
     fn aos_event_publish(

--- a/examples/log-aggregator/src/lib.rs
+++ b/examples/log-aggregator/src/lib.rs
@@ -1,5 +1,6 @@
 use std::string::String;
 
+#[link(wasm_import_module = "env")]
 extern "C" {
     fn aos_log(ptr: *const u8, len: usize);
     fn aos_event_publish(


### PR DESCRIPTION
## Summary
- WASM examples declare `aos_log` / `aos_event_publish` as `env` imports so rust-lld does not require them at link time.
- Phase 5 contract tests use `GUEST_OS=none` so `make build` does not run `fetch-guest` (which failed on missing `bsdtar`).

## Test plan
- [x] `cargo build --release` in `examples/health-monitor` and `examples/log-aggregator` (wasm32-wasip1)
- [ ] GitHub Actions: Build WASM examples + Phase 5 contract tests