### PR TITLE
Prove guest packets through emulated virtio-net

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,57 @@ jobs:
           if-no-files-found: ignore
 
   # ---------------------------------------------------------------------------
+  # Guest I/O proof: emulated virtio-net packet through linux_vmm (not GUEST_OS=none)
+  # ---------------------------------------------------------------------------
+  guest-net-proof:
+    name: Guest virtio-net packet proof (buildroot)
+    runs-on: ubuntu-24.04
+    needs: validate-topology
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install clang / lld / QEMU / dtc
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            clang lld llvm \
+            qemu-system-arm \
+            device-tree-compiler \
+            python3 curl
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Cache Microkit SDK
+        id: cache-sdk-net
+        uses: actions/cache@v4
+        with:
+          path: microkit-sdk-2.1.0
+          key: microkit-sdk-2.1.0-linux-x86-64
+
+      - name: Download Microkit SDK
+        if: steps.cache-sdk-net.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL \
+            https://github.com/seL4/microkit/releases/download/2.1.0/microkit-sdk-2.1.0-linux-x86-64.tar.gz \
+            -o microkit-sdk.tar.gz
+          tar -xzf microkit-sdk.tar.gz
+          rm microkit-sdk.tar.gz
+
+      - name: Prove guest packet through emulated virtio-net
+        timeout-minutes: 20
+        run: make test-guest-net QEMU_TEST_TIMEOUT=480
+
+      - name: Upload QEMU serial logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: guest-net-proof-logs
+          path: build/tmp/agentos-qemu-*
+          if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
   # Phase 5 contract tests — run all PD contract test suites via xtask
   # Mirrors the build-and-test job structure; runs on qemu_virt_aarch64 only.
   # ---------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,10 @@
 #   make run          — build + boot agentOS with Unix guest support in QEMU
 #   make test         — CI boot test (exit 0/1)
 #   make test-guest-login — prove Ubuntu/FreeBSD serial login via CC-PD
+#   make test-guest-net   — prove one packet through emulated virtio-net
 #   make clean        — remove build artifacts for current board
 
-.PHONY: all install deps deps-tools submodules channels run run-fast test test-guest-login sel4-test-image run-tests test-snapshot-sched test-power-mgr test-proc-server test-vibeos-contract test-integration test-host gate gate-aarch64 gate-x86_64 e2e e2e-guest e2e-contract e2e-dual-os e2e-ubuntu-amd64 e2e-ubuntu-arm64 e2e-nixos e2e-freebsd15 e2e-all bootstrap-guest clean clean-all clean-images help release release-minor release-major fetch-guest build-tools
+.PHONY: all install deps deps-tools submodules channels run run-fast test test-guest-login test-guest-net sel4-test-image run-tests test-snapshot-sched test-power-mgr test-proc-server test-vibeos-contract test-integration test-host gate gate-aarch64 gate-x86_64 e2e e2e-guest e2e-contract e2e-dual-os e2e-ubuntu-amd64 e2e-ubuntu-arm64 e2e-nixos e2e-freebsd15 e2e-all bootstrap-guest clean clean-all clean-images help release release-minor release-major fetch-guest build-tools
 
 # ─── Read config.yaml (if present) ───────────────────────────────────────────
 CONFIG_TARGET := $(shell grep '^target_arch:' config.yaml 2>/dev/null | sed 's/target_arch:[[:space:]]*//' | tr -d '[:space:]')
@@ -527,6 +528,17 @@ test-guest-login:
 	@cargo xtask qemu-test --board $(BOARD) --guest-os ubuntu --timeout-secs $(QEMU_TEST_TIMEOUT)
 	@cargo xtask qemu-test --board $(BOARD) --guest-os freebsd --timeout-secs $(QEMU_TEST_TIMEOUT)
 
+# Guest I/O proof: boot buildroot Linux under linux_vmm and require the
+# emulated virtio-net (IPA 0x0A010000) to probe, reach DRIVER_OK, and pump
+# at least one guest TX frame back onto RX. GUEST_OS=none is a stub VMM and
+# cannot prove this. Host tests/test_virtio_net_guest_path.c is not this gate.
+test-guest-net:
+	@if [ "$(BOARD)" != "qemu_virt_aarch64" ]; then \
+		echo "test-guest-net requires BOARD=qemu_virt_aarch64 (got BOARD=$(BOARD))"; \
+		exit 1; \
+	fi
+	@cargo xtask qemu-test --board qemu_virt_aarch64 --guest-os buildroot --timeout-secs $(QEMU_TEST_TIMEOUT) --assert-emulated-net
+
 # =============================================================================
 # test-snapshot-sched: standalone unit test for the snapshot_sched PD
 # =============================================================================
@@ -831,6 +843,7 @@ help:
 	@echo "  make gate             MANDATORY dual-arch QEMU gate before OS-level claims"
 	@echo "                        (host suite + aarch64 + x86_64 GUEST_OS=none boot tests)"
 	@echo "  make test-guest-login Boot Ubuntu and FreeBSD to an interactive serial prompt"
+	@echo "  make test-guest-net   Boot buildroot and prove one packet through emulated virtio-net"
 	@echo ""
 	@echo "Guest images:"
 	@echo "  make fetch-guest GUEST_OS=ubuntu     Stage Ubuntu 26.04 assets in build/guest-images"
@@ -846,6 +859,7 @@ help:
 	@echo "  make sel4-test-image  Build the seL4-target TAP test image"
 	@echo "  make run-tests        Run the seL4-target TAP test image in QEMU"
 	@echo "  make test-host        Host-only suite (alias of test-integration; NOT OS proof)"
+	@echo "  make test-guest-net   Guest packet proof: emulated virtio-net (buildroot)"
 	@echo "  make test-integration Run host-side contract/integration tests"
 	@echo "  make e2e              Run the default QEMU/guest/CC end-to-end suite"
 	@echo "  make e2e-dual-os      Run Ubuntu and FreeBSD guest E2E coverage"
@@ -867,5 +881,6 @@ help:
 	@echo "  make run-fast GUEST_OS=buildroot   # fast dev loop on Apple Silicon"
 	@echo "  make gate                          # full release gate, both arches"
 	@echo "  make test-guest-login QEMU_TEST_TIMEOUT=420"
+	@echo "  make test-guest-net QEMU_TEST_TIMEOUT=480"
 	@echo "  cd ../agentos_gui && make run"
 	@echo ""

--- a/PLAN.md
+++ b/PLAN.md
@@ -18,14 +18,14 @@ binding) described the wrong I/O model. It is superseded by this document.
 |------|----------|--------|------|
 | 1 | (done) | done | TCB page + constitution rewrite |
 | 2 | (done) | done (host-tested) | sDDF net under VMM (`virtio_mmio_net_init`), not QEMU passthrough |
-| 2b | `task_0d44a94246554eeabc8d5bc8e36ab6d7` | open | Guest must enumerate IPA `0x0A010000` and pass a packet through the pump |
-| 3 | `task_892273845b0949ce8be59f70c02bf644` | waiting on 2b | sDDF blk + emulated virtio-blk |
-| 4 | `task_9218737eb11a438b89552c599c25d012` | waiting on 2b | sDDF serial; one UART owner |
-| 5 | `task_7f6653b7dcc840b9ab7fa092685c9d57` | waiting on 2b | One VMM implementation; guest flavor is data |
-| 6 | `task_c03b1c0527de416fbcfcdfcb77787559` | waiting on 2b | Stop identity-mapping guest RAM for device DMA |
+| 2b | `task_0d44a94246554eeabc8d5bc8e36ab6d7` | done | `make test-guest-net`: boot buildroot, enumerate IPA `0x0A010000`, pump one frame |
+| 3 | `task_892273845b0949ce8be59f70c02bf644` | ready | sDDF blk + emulated virtio-blk |
+| 4 | `task_9218737eb11a438b89552c599c25d012` | waiting on 3 | sDDF serial; one UART owner |
+| 5 | `task_7f6653b7dcc840b9ab7fa092685c9d57` | waiting on 3 | One VMM implementation; guest flavor is data |
+| 6 | `task_c03b1c0527de416fbcfcdfcb77787559` | waiting on 3 | Stop identity-mapping guest RAM for device DMA |
 | 7 | (done) | done (quarantine by docs) | Quarantine PD museum (no deletes this pass) |
 | 8 | (done) | done | Skills + Python HTML helpers |
-| 9 | `task_ec992e5743354a538d1c3235a2e2c0da` | waiting on 2b | Native agent services as virtualizer clients |
+| 9 | `task_ec992e5743354a538d1c3235a2e2c0da` | waiting on 3 | Native agent services as virtualizer clients |
 
 ## Proof policy (unchanged)
 
@@ -62,7 +62,9 @@ services is out of scope until inspect and serial attach exist.
 
 1. Guest IPA `0x0A010000` is an **emulated** virtio-mmio net device (fault to VMM).
 2. Backend is sDDF-shaped queues + `aos_net_virt_pump` (loopback / hub).
-3. Guest DTB advertises this device. QEMU virtio-net at `0x0A000000` stays as
-   a kill-dated crutch so existing SSH E2E does not go dark in this pass.
-4. Next: host virtio-net MMIO moves to a nic_drv PD; passthrough is removed;
-   both guests share one `net_virt`.
+3. Guest DTB advertises this device. Buildroot overlay has **only** the
+   emulated NIC (`make test-guest-net`). Ubuntu overlays still carry QEMU
+   virtio-net at `0x0A000000` as a kill-dated SSH crutch until nic_drv
+   exists.
+4. Next: host virtio-net MMIO moves to a nic_drv PD; passthrough is removed
+   from Ubuntu too; both guests share one `net_virt`.

--- a/kernel/agentos-root-task/Makefile
+++ b/kernel/agentos-root-task/Makefile
@@ -39,7 +39,7 @@ else
   $(error Unsupported arch: $(ARCH))
 endif
 
-CFLAGS := -nostdlib -ffreestanding -g -O2 -Wall -Wextra -Werror -Wno-unused-function -Wno-unused-parameter -Wno-unused-variable \
+CFLAGS := -nostdlib -ffreestanding -g -O2 -Wall -Wextra -Werror -Wno-unused-function -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable \
            -Iinclude -Ilwip/include -I$(SEL4_INC_DIR) \
            $(CFLAGS_ARCH) \
            -DCONFIG_KERNEL_MCS \

--- a/kernel/agentos-root-task/src/linux_vmm.c
+++ b/kernel/agentos-root-task/src/linux_vmm.c
@@ -450,9 +450,19 @@ __attribute__((used)) seL4_Word    microkit_signal_msg    = 0;
 
 /* PL011 UART on QEMU virt — direct write, no seL4_DebugPutChar needed */
 #define LINUX_VMM_UART_VA 0x10001000UL
+#define LINUX_VMM_UARTFR_TXFF (1u << 5)
 static inline void _uart_putc(char c) {
+    volatile uint32_t *fr = (volatile uint32_t *)(LINUX_VMM_UART_VA + 0x18UL);
     volatile uint32_t *dr = (volatile uint32_t *)LINUX_VMM_UART_VA;
+    while (*fr & LINUX_VMM_UARTFR_TXFF) {
+        /* wait until the TX FIFO has room */
+    }
     *dr = (uint32_t)(unsigned char)c;
+}
+
+void _putchar(char character)
+{
+    _uart_putc(character);
 }
 
 void microkit_dbg_putc(char c) { _uart_putc(c); }
@@ -471,9 +481,9 @@ void microkit_dbg_put32(uint32_t v)
 }
 
 /* seL4 IPC buffer pointer. Compiled with -D__thread= (TLS suppressed) so
- * this is a regular global matching libvmm.a's expectation. The frame is
- * mapped by the CapDL initializer at __sel4_ipc_buffer_obj's VA, set via
- * seL4_SetIPCBuffer() in linux_vmm_main() before any seL4 IPC calls. */
+ * this is a regular global matching libvmm.a (vmm_wrapper_template.mk).
+ * linux_vmm_main() points it at the mapped page (0x10000000) before any
+ * seL4 invocation that uses extra message registers. */
 seL4_IPCBuffer *__sel4_ipc_buffer = NULL;
 
 /* vmm_caps.c is not included in libvmm.a — define g_vmm_vcpus here.
@@ -1041,6 +1051,7 @@ static bool linux_vmm_start_guest(void)
     }
 
     LOG_VMM("  Starting Linux guest...\n");
+    vcpu_reset(GUEST_BOOT_VCPU_ID);
     guest_start(g_linux_kernel_pc, GUEST_DTB_VADDR, GUEST_INIT_RAM_DISK_VADDR);
     guest_started = true;
     g_guest_state = GUEST_STATE_RUNNING;
@@ -1627,11 +1638,36 @@ static void linux_vmm_notified(seL4_Word badge)
 static seL4_MessageInfo_t linux_vmm_fault(seL4_Word badge,
                                           seL4_MessageInfo_t msginfo)
 {
-    /* Microkit 2.1 encodes VCPU fault badges as (1ULL<<62)|vcpu_id.
-     * Strip the upper flag bits to recover the raw vcpu_id. */
+    /* Bit 62 is the Microkit VCPU-fault flag when present. Unbadged
+     * deliveries (guest TCB fault handler = VMM listen EP) are vCPU 0. */
     size_t vcpu_id = badge & ~VMM_FAULT_BADGE_FLAG;
+    seL4_Word label = seL4_MessageInfo_get_label(msginfo);
+
+    {
+        static uint32_t fault_log;
+        if (fault_log < 8u) {
+            fault_log++;
+            LOG_VMM("guest fault #%u label=0x%lx badge=0x%lx vcpu=%lu\n",
+                    (unsigned)fault_log, (unsigned long)label,
+                    (unsigned long)badge, (unsigned long)vcpu_id);
+            if (label == seL4_Fault_VMFault) {
+                LOG_VMM("  VMFault ip=0x%lx addr=0x%lx fsr=0x%lx\n",
+                        (unsigned long)seL4_GetMR(seL4_VMFault_IP),
+                        (unsigned long)seL4_GetMR(seL4_VMFault_Addr),
+                        (unsigned long)seL4_GetMR(seL4_VMFault_FSR));
+            } else if (label == seL4_Fault_VCPUFault) {
+                LOG_VMM("  VCPUFault HSR=0x%lx\n",
+                        (unsigned long)seL4_GetMR(seL4_VCPUFault_HSR));
+            } else {
+                LOG_VMM("\n");
+            }
+        }
+    }
 
     bool success = fault_handle(vcpu_id, msginfo);
+    if (!success) {
+        LOG_VMM_ERR("fault_handle failed label=0x%lx\n", (unsigned long)label);
+    }
     (void)success;
     /* Guest virtio-net QueueNotify is an MMIO fault; pump sDDF → RX virtq. */
     aos_vmm_virtio_net_after_fault();
@@ -1649,8 +1685,10 @@ static seL4_MessageInfo_t linux_vmm_fault(seL4_Word badge,
  */
 void linux_vmm_main(seL4_CPtr ep, seL4_CPtr reply_cap)
 {
-    /* __sel4_ipc_buffer is set to 0x10000000 by pd_entry.c _start before
-     * this function is called; no need to set it again here. */
+    /* Same as freebsd_vmm: pin the mapped IPC page before libvmm inlines
+     * seL4_TCB_WriteRegisters (38 MRs through seL4_GetIPCBuffer). pd_entry
+     * also assigns the global; this call is the one that must not be skipped. */
+    seL4_SetIPCBuffer((seL4_IPCBuffer *)0x10000000UL);
 
     /* Run init() — sets up guest images, GIC, virtio IRQs, starts guest */
     init();
@@ -1688,7 +1726,7 @@ void linux_vmm_main(seL4_CPtr ep, seL4_CPtr reply_cap)
             seL4_Reply(reply);
             info = seL4_Recv(ep, &badge);
 #endif
-        } else if (label == seL4_Fault_NullFault || !(badge & VMM_FAULT_BADGE_FLAG)) {
+        } else if (label == seL4_Fault_NullFault) {
             linux_vmm_notified(badge);
 #ifdef CONFIG_KERNEL_MCS
             info = seL4_Recv(ep, &badge, reply_cap);

--- a/kernel/agentos-root-task/src/main.c
+++ b/kernel/agentos-root-task/src/main.c
@@ -109,6 +109,11 @@ static seL4_Word g_cap_base;  /* set to bi->empty.start in root_task_main */
 #define VMM_GUEST_TCB_SLOT_BASE   266u
 #define VMM_GUEST_VCPU_SLOT_BASE  330u
 #define VMM_FAULT_BADGE_BASE      (1ULL << 62)
+/* Guest TCB IPC buffer: next 4K after the debug UART page. Must not share
+ * the VMM thread's buffer — seL4 forbids two TCBs on one IPC page, and a
+ * guest VMFault would clobber in-flight VMM syscalls. L1 for
+ * [0x10000000, 0x11FFFFF] is already installed with the VMM IPC mapping. */
+#define VMM_GUEST_IPC_BUF_VA      0x0000000010002000UL
 
 /* Active PD scheduling defaults.
  *
@@ -892,10 +897,8 @@ static seL4_Error setup_vmm_guest_vcpu(const pd_desc_t *pd,
 
     seL4_Word guest_tcb_slot = ut_alloc_slot();
     seL4_Word guest_vcpu_slot = ut_alloc_slot();
-    seL4_Word guest_fault_ep_slot = ut_alloc_slot();
     if (guest_tcb_slot == seL4_CapNull ||
-        guest_vcpu_slot == seL4_CapNull ||
-        guest_fault_ep_slot == seL4_CapNull) {
+        guest_vcpu_slot == seL4_CapNull) {
         dbg_puts("[rt] VMM guest setup failed: no root CNode slots\n");
         return seL4_NotEnoughMemory;
     }
@@ -924,6 +927,24 @@ static seL4_Error setup_vmm_guest_vcpu(const pd_desc_t *pd,
         return err;
     }
 
+    seL4_CPtr guest_ipc_cap = seL4_CapNull;
+    err = ut_alloc_cap(seL4_ARM_SmallPageObject, 0u, &guest_ipc_cap);
+    if (err != seL4_NoError) {
+        dbg_puts("[rt] VMM guest IPC frame alloc err=");
+        dbg_hex((seL4_Word)err);
+        dbg_puts("\n");
+        return err;
+    }
+    err = pd_vspace_map_device_frame(vspace, guest_ipc_cap, VMM_GUEST_IPC_BUF_VA);
+    if (err != seL4_NoError) {
+        dbg_puts("[rt] VMM guest IPC map err=");
+        dbg_hex((seL4_Word)err);
+        dbg_puts("\n");
+        return err;
+    }
+    (void)ipc_buf_va;
+    (void)ipc_buf_cap;
+
     seL4_Word cspace_root_data =
         (seL4_Word)(seL4_WordBits - (uint32_t)pd->cnode_size_bits);
     err = seL4_TCB_Configure((seL4_CPtr)guest_tcb_slot,
@@ -931,8 +952,8 @@ static seL4_Error setup_vmm_guest_vcpu(const pd_desc_t *pd,
                               cspace_root_data,
                               vspace,
                               0u,
-                              ipc_buf_va,
-                              ipc_buf_cap);
+                              VMM_GUEST_IPC_BUF_VA,
+                              guest_ipc_cap);
     if (err != seL4_NoError) {
         dbg_puts("[rt] VMM guest TCB configure err=");
         dbg_hex((seL4_Word)err);
@@ -974,24 +995,16 @@ static seL4_Error setup_vmm_guest_vcpu(const pd_desc_t *pd,
         return err;
     }
 
-    err = ep_mint_badge(self_ep,
-                        (seL4_Word)(VMM_FAULT_BADGE_BASE | 0u),
-                        seL4_CapInitThreadCNode,
-                        guest_fault_ep_slot,
-                        64u);
-    if (err != seL4_NoError) {
-        dbg_puts("[rt] VMM guest fault EP mint err=");
-        dbg_hex((seL4_Word)err);
-        dbg_puts("\n");
-        return err;
-    }
-
     err = seL4_TCB_SetSchedParams((seL4_CPtr)guest_tcb_slot,
                                   seL4_CapInitThreadTCB,
                                   255u,
                                   (seL4_Word)pd->priority,
                                   (seL4_CPtr)guest_sc_slot,
-                                  (seL4_CPtr)guest_fault_ep_slot);
+                                  /* Guest faults must land on the VMM listen EP.
+                                   * PD TCBs use a raw endpoint cap here (g_fault_ep).
+                                   * A badged mint was accepted but VCPUFaults still
+                                   * arrived on the root-task fault EP instead. */
+                                  self_ep);
     if (err != seL4_NoError) {
         dbg_puts("[rt] VMM guest SetSchedParams err=");
         dbg_hex((seL4_Word)err);
@@ -1057,6 +1070,8 @@ static seL4_Error setup_vmm_guest_vcpu(const pd_desc_t *pd,
     dbg_hex((seL4_Word)guest_tcb_slot);
     dbg_puts(" vcpu=");
     dbg_hex((seL4_Word)guest_vcpu_slot);
+    dbg_puts(" ipc_va=");
+    dbg_hex((seL4_Word)VMM_GUEST_IPC_BUF_VA);
     dbg_puts("\n");
     return seL4_NoError;
 }

--- a/kernel/agentos-root-task/src/vibe_swap.c
+++ b/kernel/agentos-root-task/src/vibe_swap.c
@@ -258,7 +258,6 @@ typedef struct {
 /* ── Module state ───────────────────────────────────────────────────────── */
 static swap_slot_t    slots[MAX_SWAP_SLOTS];
 static service_desc_t services[VS_MAX_SERVICES];
-static int            service_count = 0;
 static uint64_t       swap_sequence = 0;
 
 static sel4_server_t  g_srv;
@@ -326,7 +325,6 @@ void vibe_swap_init(void)
         .active_ep = 0, .primary_ep = 0,
         .version = 1, .has_rollback = false,
     };
-    service_count = 6;
 
     vs_dbg_puts("[vibe_swap] Ready for vibe-coded service proposals\n");
 }

--- a/kernel/agentos-root-task/vmm.mk
+++ b/kernel/agentos-root-task/vmm.mk
@@ -54,7 +54,8 @@ DTS_OVERLAY_FILE := $(UBUNTU_DTS_OVERLAY)
 else
 LINUX_IMAGE  := $(BUILD_DIR)/$(BUILDROOT_LINUX_IMAGE)
 INITRD_IMAGE := $(BUILD_DIR)/$(BUILDROOT_INITRD_IMAGE)
-DTS_OVERLAY_FILE = $(DTS_DIR)/overlay.dts
+DTS_OVERLAY_FILE := $(BUILD_DIR)/buildroot-overlay.dts
+BUILDROOT_INITRD_START := 0x50000000
 endif
 
 # DTS + tools
@@ -155,6 +156,18 @@ $(UBUNTU_DTS_OVERLAY): $(KERNEL_SRC_DIR)/ubuntu-iso-overlay.dts.in $(KERNEL_SRC_
 		-e 's|@UBUNTU_RAM_BASE@|0x00 $(UBUNTU_RAM_BASE)|g' \
 		-e 's|@UBUNTU_INITRD_START@|0x00 $(UBUNTU_INITRD_START)|g' \
 		-e "s|@UBUNTU_INITRD_END@|0x00 $$end_hex|g" \
+		$< > $@
+
+$(BUILD_DIR)/buildroot-overlay.dts: $(DTS_DIR)/overlay.dts $(KERNEL_SRC_DIR)/vmm.mk $(INITRD_IMAGE) $(VMM_CONFIG_STAMP)
+	@mkdir -p $(BUILD_DIR)
+	@echo "[VMM] Generating buildroot overlay (initrd at $(BUILDROOT_INITRD_START))..."
+	@initrd_size=$$(python3 -c 'import os,sys; print(os.path.getsize(sys.argv[1]))' "$(INITRD_IMAGE)"); \
+	start=$$(( $(BUILDROOT_INITRD_START) )); \
+	end=$$(( start + initrd_size )); \
+	end_hex=$$(printf "0x%08x" $$end); \
+	sed \
+		-e 's|@BUILDROOT_INITRD_START@|0x00 $(BUILDROOT_INITRD_START)|g' \
+		-e "s|@BUILDROOT_INITRD_END@|0x00 $$end_hex|g" \
 		$< > $@
 
 $(BUILD_DIR)/vm.dts: FORCE $(LINUX_DTS_BASE) $(DTS_OVERLAY_FILE)

--- a/kernel/agentos-root-task/vmm_wrapper_template.mk
+++ b/kernel/agentos-root-task/vmm_wrapper_template.mk
@@ -16,12 +16,18 @@ RANLIB := $(shell command -v llvm-ranlib 2>/dev/null || command -v /opt/homebrew
 
 SDDF_CUSTOM_LIBC := 1
 
+# -D__thread= is mandatory and must match linux_vmm.c / pd_entry.c (VMM_CFLAGS).
+# libsel4 declares __sel4_ipc_buffer as extern __thread. Without this, libvmm.a
+# (guest_start → seL4_TCB_WriteRegisters, 38 MRs) uses a TLS copy that stays
+# NULL and VMFaults at address 0. linux_vmm's global is a different symbol.
 CFLAGS := \
     -mstrict-align \
     -ffreestanding \
     -g3 -O3 -Wall \
     -Wno-unused-function \
     -DBOARD_qemu_virt_aarch64 \
+    -D__thread= \
+    -DAOS_NO_UBSAN=1 \
     -I$(BOARD_DIR)/include \
     -I$(LIBVMM)/include \
     -I$(SDDF)/include \
@@ -36,6 +42,11 @@ vpath %.c $(LIBVMM)
 
 include $(LIBVMM)/vmm.mk
 include $(SDDF)/util/util.mk
+
+# libvmm.mk adds -fsanitize-trap=undefined (brk). In this PD that trap is a
+# VCPUFault/UserException with no handler: the guest dies after the first
+# emulated MMIO. Strip it after the include so CHECK_LIBVMM_CFLAGS rebuilds.
+CFLAGS := $(filter-out -fsanitize=undefined -fsanitize-trap=undefined,$(CFLAGS))
 
 # smc.c calls seL4_ARM_SMC() which is a typedef (not a function) in Microkit SDK 2.1.
 # Override the pattern rule with a stub that compiles cleanly.  On QEMU virt,

--- a/libvmm/examples/simple/board/qemu_virt_aarch64/overlay.dts
+++ b/libvmm/examples/simple/board/qemu_virt_aarch64/overlay.dts
@@ -2,12 +2,19 @@
  * Copyright 2024, UNSW
  *
  * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Buildroot guest overlay. vmm.mk fills @BUILDROOT_INITRD_*@ from the
+ * packaged initrd size. RAM / initrd IPA must match linux_vmm.c
+ * (LINUX_GUEST_RAM_VADDR / GUEST_INIT_RAM_DISK_VADDR / GUEST_RAM_SIZE).
+ *
+ * Guest net is the emulated virtio-mmio at 0xa010000 only. QEMU virtio-net
+ * at 0xa000000 is not in this tree so TX goes through aos_net_virt_pump.
  */
 / {
     /* Need to specify how much RAM the guest will have */
     memory@40000000 {
         device_type = "memory";
-        reg = <0x00 0x40000000 0x00 0x10000000>;
+        reg = <0x00 0x40000000 0x00 0x20000000>;
     };
 
     flash@0 {
@@ -16,25 +23,10 @@
 
     chosen {
         stdout-path = "/pl011@9000000";
-        bootargs = "earlycon=pl011,0x9000000 earlyprintk=serial debug loglevel=8";
+        bootargs = "earlycon=pl011,0x9000000 console=ttyAMA0,115200n8 earlyprintk=serial debug loglevel=8 ip=dhcp";
         linux,stdout-path = "/pl011@9000000";
-        linux,initrd-start = <0x4d000000>;
-        linux,initrd-end = <0x4d800000>;
-    };
-
-    /*
-     * virtio-net passthrough: QEMU virt virtio-mmio slot 0.
-     * Physical address: 0xa000000 + 0*0x200 = 0xa000000.
-     * IRQ: SPI 16 (INTID 48) — QEMU assigns SPI (16+slot) per transport.
-     * Slot 0 is chosen explicitly: QEMU command uses bus=virtio-mmio-bus.0.
-     * interrupt-parent 0x8001 = intc@8000000 (GIC) phandle in linux.dts.
-     * trigger 0x01 = edge-rising (matches QEMU's virt machine DT for slot 0).
-     */
-    virtio_mmio@a000000 {
-        compatible = "virtio,mmio";
-        reg = <0x00 0xa000000 0x00 0x200>;
-        interrupt-parent = <0x8001>;
-        interrupts = <0x00 0x10 0x01>;
+        linux,initrd-start = <@BUILDROOT_INITRD_START@>;
+        linux,initrd-end = <@BUILDROOT_INITRD_END@>;
     };
 
     /* agentOS emulated virtio-net (not QEMU). SPI 18 → INTID 50. */
@@ -45,18 +37,4 @@
         interrupt-parent = <0x8001>;
         interrupts = <0x00 0x12 0x01>;
     };
-
-    /*
-     * agentOS emulated virtio-blk — NOT LIVE this pass.
-     * IPA 0xa020000 / SPI 20 → INTID 52. Do not enable until it can
-     * replace QEMU virtio-blk without stealing the boot disk.
-     *
-     * virtio_mmio@a020000 {
-     *     compatible = "virtio,mmio";
-     *     dma-coherent;
-     *     reg = <0x00 0xa020000 0x00 0x1000>;
-     *     interrupt-parent = <0x8001>;
-     *     interrupts = <0x00 0x14 0x01>;
-     * };
-     */
 };

--- a/libvmm/src/util/util.c
+++ b/libvmm/src/util/util.c
@@ -8,10 +8,9 @@
 #include <libvmm/util/util.h>
 #include <libvmm/util/printf.h>
 
-/* This is required to use the printf library we brought in, it is
-   simply for convenience since there's a lot of logging/debug printing
-   in the VMM. */
-void _putchar(char character)
+/* Weak so linux_vmm can send printf to the mapped PL011 (release seL4 has
+ * CONFIG_PRINTING off; seL4_DebugPutChar is then a no-op). */
+__attribute__((weak)) void _putchar(char character)
 {
     seL4_DebugPutChar(character);
 }

--- a/libvmm/src/virtio/block.c
+++ b/libvmm/src/virtio/block.c
@@ -245,6 +245,15 @@ static bool handle_client_requests(struct virtio_device *dev, int *num_reqs_cons
     virtio_queue_handler_t *vq = &dev->vqs[VIRTIO_BLK_DEFAULT_VIRTQ];
     struct virtq *virtq = &vq->virtq;
 
+    /*
+     * after_fault pumps on every guest MMIO (UART/GIC first). The virtq
+     * pointers stay NULL until the guest writes QUEUE_READY.
+     */
+    if (!vq->ready || virtq->avail == NULL || virtq->desc == NULL || virtq->used == NULL) {
+        *num_reqs_consumed = 0;
+        return true;
+    }
+
     struct virtio_blk_device *state = device_state(dev);
 
     /* If any request has to be dropped due to any number of reasons, such as an invalid req, this becomes

--- a/platform/blk-virt/vmm_virtio_blk.c
+++ b/platform/blk-virt/vmm_virtio_blk.c
@@ -88,10 +88,18 @@ void aos_vmm_virtio_blk_init(void)
 
 void aos_vmm_virtio_blk_after_fault(void)
 {
+    virtio_queue_handler_t *vq;
+
     if (!g_aos_blk_ready) {
         return;
     }
     (void)aos_blk_virt_pump(&g_aos_virt);
+
+    vq = &g_aos_blk.virtio_device.vqs[VIRTIO_BLK_DEFAULT_VIRTQ];
+    if (!vq->ready || vq->virtq.avail == NULL) {
+        return;
+    }
+
     (void)virtio_blk_handle_resp(&g_aos_blk);
     /* Keep plugged so a later handle_resp enqueue cannot unplug. */
     if (g_queue.req_queue) {

--- a/platform/net-virt/vmm_virtio_net.c
+++ b/platform/net-virt/vmm_virtio_net.c
@@ -27,6 +27,7 @@ static net_queue_handle_t       g_tx;
 static int                      g_aos_net_ready;
 static int                      g_aos_net_probed;
 static int                      g_aos_net_driver_ok;
+static int                      g_aos_net_pumped;
 
 void aos_vmm_guest_ram_bind(uint64_t gpa_base, uintptr_t hva_base, size_t size)
 {
@@ -89,6 +90,7 @@ void aos_vmm_virtio_net_init(void)
 void aos_vmm_virtio_net_after_fault(void)
 {
     uint32_t status;
+    uint32_t n;
 
     if (!g_aos_net_ready) {
         return;
@@ -102,11 +104,21 @@ void aos_vmm_virtio_net_after_fault(void)
     }
     if (!g_aos_net_driver_ok && (status & VIRTIO_CONFIG_S_DRIVER_OK)) {
         g_aos_net_driver_ok = 1;
-        LOG_VMM("emulated virtio-net: guest DRIVER_OK virq %u\n",
-                (unsigned)AOS_VIRTIO_NET_VIRQ);
+        LOG_VMM("emulated virtio-net: guest DRIVER_OK virq %u MAC %02x:%02x:%02x:%02x:%02x:%02x\n",
+                (unsigned)AOS_VIRTIO_NET_VIRQ,
+                (unsigned)AOS_VIRTIO_NET_MAC0,
+                (unsigned)AOS_VIRTIO_NET_MAC1,
+                (unsigned)AOS_VIRTIO_NET_MAC2,
+                (unsigned)AOS_VIRTIO_NET_MAC3,
+                (unsigned)AOS_VIRTIO_NET_MAC4,
+                (unsigned)AOS_VIRTIO_NET_MAC5);
     }
 
-    (void)aos_net_virt_pump(&g_aos_virt);
+    n = aos_net_virt_pump(&g_aos_virt);
+    if (!g_aos_net_pumped && n > 0u) {
+        g_aos_net_pumped = 1;
+        LOG_VMM("emulated virtio-net: pumped %u frame(s) TX->RX\n", n);
+    }
     (void)virtio_net_handle_rx(&g_aos_net);
     if (g_tx.active) {
         g_tx.active->consumer_signalled = 1u;

--- a/tests/platform/test_virtio_net_guest_path.c
+++ b/tests/platform/test_virtio_net_guest_path.c
@@ -516,9 +516,30 @@ int main(void)
                    "DTB ubuntu-iso-overlay.dts.in has virtio_mmio@a010000");
     (void)test_dtb("libvmm/examples/simple/board/qemu_virt_aarch64/overlay.dts",
                    "DTB buildroot overlay.dts has virtio_mmio@a010000");
+    (void)tap_ok(!src_contains("libvmm/examples/simple/board/qemu_virt_aarch64/overlay.dts",
+                               "virtio_mmio@a000000"),
+                 "buildroot overlay.dts has no QEMU virtio-net at 0xa000000");
     (void)test_dtb("libvmm/examples/simple/board/qemu_virt_aarch64/ubuntu-overlay.dts",
                    "DTB ubuntu-overlay.dts has virtio_mmio@a010000");
     (void)test_vmm_fault_path();
+    (void)tap_ok(src_contains("kernel/agentos-root-task/vmm_wrapper_template.mk",
+                              "-D__thread="),
+                 "libvmm.a CFLAGS suppress TLS so IPC buffer matches linux_vmm");
+    (void)tap_ok(src_contains("kernel/agentos-root-task/src/linux_vmm.c",
+                              "seL4_SetIPCBuffer"),
+                 "linux_vmm_main pins mapped IPC buffer before guest_start");
+    (void)tap_ok(src_contains("kernel/agentos-root-task/src/linux_vmm.c",
+                              "} else if (label == seL4_Fault_NullFault) {"),
+                 "linux_vmm treats hypervisor faults as faults, not notifications");
+    (void)tap_ok(src_contains("kernel/agentos-root-task/vmm_wrapper_template.mk",
+                              "filter-out -fsanitize=undefined"),
+                 "libvmm.a is not built with UBSan trap-to-brk");
+    (void)tap_ok(src_contains("libvmm/src/virtio/block.c",
+                              "virtq->avail == NULL"),
+                 "virtio-blk skips avail->idx until the guest programs the virtq");
+    (void)tap_ok(src_contains("platform/net-virt/vmm_virtio_net.c",
+                              "guest DRIVER_OK virq %u MAC"),
+                 "VMM logs guest MAC 02:00:00:00:00:01 at DRIVER_OK");
     (void)test_qemu_page_unmapped();
     (void)test_mmio_probe();
     (void)test_guest_tx_rx_loopback();

--- a/xtask/src/cmd_test.rs
+++ b/xtask/src/cmd_test.rs
@@ -35,6 +35,17 @@ const VIBEOS_DEV_BLOCK: u32 = 1 << 2;
 pub fn run(args: &TestArgs) -> anyhow::Result<()> {
     let repo_root = repo_root()?;
 
+    if args.assert_emulated_net {
+        anyhow::ensure!(
+            args.board == "qemu_virt_aarch64",
+            "--assert-emulated-net requires --board qemu_virt_aarch64"
+        );
+        anyhow::ensure!(
+            args.guest_os != "none",
+            "--assert-emulated-net needs a real guest (buildroot or ubuntu); GUEST_OS=none is a stub VMM"
+        );
+    }
+
     if !args.no_build {
         println!(
             "[xtask:test] Building BOARD={} GUEST_OS={}...",
@@ -86,7 +97,14 @@ pub fn run(args: &TestArgs) -> anyhow::Result<()> {
         ssh_port,
     )?;
 
-    let result = match args.guest_os.as_str() {
+    let result = if args.assert_emulated_net {
+        println!(
+            "[xtask:test] Waiting for emulated virtio-net guest proof in {}...",
+            log_path.display()
+        );
+        wait_for_emulated_net(&log_path, Duration::from_secs(args.timeout_secs))
+    } else {
+        match args.guest_os.as_str() {
         "ubuntu" => {
             println!(
                 "[xtask:test] Waiting for Ubuntu login prompt via CC-PD API ({})...",
@@ -139,6 +157,7 @@ pub fn run(args: &TestArgs) -> anyhow::Result<()> {
                     Duration::from_secs(args.timeout_secs),
                 )
             }
+        }
         }
     };
 
@@ -622,6 +641,65 @@ pub fn wait_for_markers(
                 if accumulated.contains(marker) {
                     return Ok(marker.to_string());
                 }
+            }
+        }
+
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}
+
+const EMU_NET_REQUIRED: &[&str] = &[
+    "emulated virtio-net: guest probed",
+    "emulated virtio-net: guest DRIVER_OK",
+    "emulated virtio-net: pumped",
+];
+
+const EMU_NET_GUEST_ANY: &[&str] = &[
+    "0a010000.virtio_mmio",
+    "a010000.virtio_mmio",
+    "02:00:00:00:00:01",
+    "Sending DHCP requests",
+];
+
+fn wait_for_emulated_net(log_path: &Path, timeout: Duration) -> anyhow::Result<String> {
+    let start = Instant::now();
+    let mut file = std::fs::File::open(log_path).context("failed to open log file")?;
+    let mut offset: u64 = 0;
+    let mut accumulated = String::new();
+
+    loop {
+        if start.elapsed() >= timeout {
+            let missing: Vec<&str> = EMU_NET_REQUIRED
+                .iter()
+                .copied()
+                .filter(|m| !accumulated.contains(m))
+                .collect();
+            let guest_ok = EMU_NET_GUEST_ANY
+                .iter()
+                .any(|m| accumulated.contains(m));
+            anyhow::bail!(
+                "emulated virtio-net proof timeout after {}s; missing VMM markers {:?}; guest IPA/MAC observed={}",
+                timeout.as_secs(),
+                missing,
+                guest_ok
+            );
+        }
+
+        file.seek(SeekFrom::Start(offset))?;
+        let mut raw = Vec::new();
+        let bytes_read = file.read_to_end(&mut raw)?;
+        if bytes_read > 0 {
+            offset += bytes_read as u64;
+            accumulated.push_str(&String::from_utf8_lossy(&raw));
+
+            let vmm_ok = EMU_NET_REQUIRED
+                .iter()
+                .all(|m| accumulated.contains(m));
+            let guest_ok = EMU_NET_GUEST_ANY
+                .iter()
+                .any(|m| accumulated.contains(m));
+            if vmm_ok && guest_ok {
+                return Ok("emulated virtio-net: guest probed + DRIVER_OK + pumped + guest IPA/MAC".to_string());
             }
         }
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -34,6 +34,10 @@ pub struct TestArgs {
     pub timeout_secs: u64,
     #[arg(long)]
     pub no_build: bool,
+    /// Require emulated virtio-net probe + DRIVER_OK + a pumped frame.
+    /// Host tests are not this proof. GUEST_OS=none is a stub VMM.
+    #[arg(long)]
+    pub assert_emulated_net: bool,
 }
 
 #[derive(clap::Args)]


### PR DESCRIPTION
## Summary
- Boot buildroot under `linux_vmm` with **only** emulated virtio-mmio net at IPA `0x0A010000` (QEMU virtio-net at `0xa000000` removed from the buildroot overlay).
- Guest TX of a DHCP frame is looped by `aos_net_virt_pump` onto RX. `make test-guest-net` now passes: probed, DRIVER_OK, pumped, guest MAC/DHCP observed.
- Fixes that were killing the VMM on the first UART MMIO: TLS `__sel4_ipc_buffer` in libvmm, UBSan trap-to-brk, and `virtio_blk_handle_resp` dereferencing a NULL avail ring.

## Test plan
- [x] `make test-host`
- [x] `make test-guest-net QEMU_TEST_TIMEOUT=480` (PASS: probed + DRIVER_OK + pumped + guest IPA/MAC)
- [ ] CI job `guest-net-proof` on this PR