### PR TITLE
Prove guest I/O through emulated virtio-blk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,57 @@ jobs:
           if-no-files-found: ignore
 
   # ---------------------------------------------------------------------------
+  # Guest I/O proof: emulated virtio-blk request through linux_vmm (not GUEST_OS=none)
+  # ---------------------------------------------------------------------------
+  guest-blk-proof:
+    name: Guest virtio-blk I/O proof (buildroot)
+    runs-on: ubuntu-24.04
+    needs: validate-topology
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install clang / lld / QEMU / dtc
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            clang lld llvm \
+            qemu-system-arm \
+            device-tree-compiler \
+            python3 curl
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Cache Microkit SDK
+        id: cache-sdk-blk
+        uses: actions/cache@v4
+        with:
+          path: microkit-sdk-2.1.0
+          key: microkit-sdk-2.1.0-linux-x86-64
+
+      - name: Download Microkit SDK
+        if: steps.cache-sdk-blk.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL \
+            https://github.com/seL4/microkit/releases/download/2.1.0/microkit-sdk-2.1.0-linux-x86-64.tar.gz \
+            -o microkit-sdk.tar.gz
+          tar -xzf microkit-sdk.tar.gz
+          rm microkit-sdk.tar.gz
+
+      - name: Prove guest I/O through emulated virtio-blk
+        timeout-minutes: 20
+        run: make test-guest-blk QEMU_TEST_TIMEOUT=480
+
+      - name: Upload QEMU serial logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: guest-blk-proof-logs
+          path: build/tmp/agentos-qemu-*
+          if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
   # Phase 5 contract tests — run all PD contract test suites via xtask
   # Mirrors the build-and-test job structure; runs on qemu_virt_aarch64 only.
   # ---------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,10 @@
 #   make test         — CI boot test (exit 0/1)
 #   make test-guest-login — prove Ubuntu/FreeBSD serial login via CC-PD
 #   make test-guest-net   — prove one packet through emulated virtio-net
+#   make test-guest-blk   — prove one request through emulated virtio-blk
 #   make clean        — remove build artifacts for current board
 
-.PHONY: all install deps deps-tools submodules channels run run-fast test test-guest-login test-guest-net sel4-test-image run-tests test-snapshot-sched test-power-mgr test-proc-server test-vibeos-contract test-integration test-host gate gate-aarch64 gate-x86_64 e2e e2e-guest e2e-contract e2e-dual-os e2e-ubuntu-amd64 e2e-ubuntu-arm64 e2e-nixos e2e-freebsd15 e2e-all bootstrap-guest clean clean-all clean-images help release release-minor release-major fetch-guest build-tools
+.PHONY: all install deps deps-tools submodules channels run run-fast test test-guest-login test-guest-net test-guest-blk sel4-test-image run-tests test-snapshot-sched test-power-mgr test-proc-server test-vibeos-contract test-integration test-host gate gate-aarch64 gate-x86_64 e2e e2e-guest e2e-contract e2e-dual-os e2e-ubuntu-amd64 e2e-ubuntu-arm64 e2e-nixos e2e-freebsd15 e2e-all bootstrap-guest clean clean-all clean-images help release release-minor release-major fetch-guest build-tools
 
 # ─── Read config.yaml (if present) ───────────────────────────────────────────
 CONFIG_TARGET := $(shell grep '^target_arch:' config.yaml 2>/dev/null | sed 's/target_arch:[[:space:]]*//' | tr -d '[:space:]')
@@ -539,6 +540,18 @@ test-guest-net:
 	fi
 	@cargo xtask qemu-test --board qemu_virt_aarch64 --guest-os buildroot --timeout-secs $(QEMU_TEST_TIMEOUT) --assert-emulated-net
 
+# Guest I/O proof: boot buildroot Linux under linux_vmm and require the
+# emulated virtio-blk (IPA 0x0A020000) to probe, reach DRIVER_OK, and pump
+# at least one guest request (partition scan of the RAM disk). Host
+# tests/test_virtio_blk_guest_path.c is not this gate. Ubuntu still boots
+# from QEMU virtio-blk at 0x0A000200 — do not enable emulated blk there yet.
+test-guest-blk:
+	@if [ "$(BOARD)" != "qemu_virt_aarch64" ]; then \
+		echo "test-guest-blk requires BOARD=qemu_virt_aarch64 (got BOARD=$(BOARD))"; \
+		exit 1; \
+	fi
+	@cargo xtask qemu-test --board qemu_virt_aarch64 --guest-os buildroot --timeout-secs $(QEMU_TEST_TIMEOUT) --assert-emulated-blk
+
 # =============================================================================
 # test-snapshot-sched: standalone unit test for the snapshot_sched PD
 # =============================================================================
@@ -689,6 +702,16 @@ test-integration:
 	    echo "PASS: tests/platform/test_blk_virt_pump.c"; \
 	else \
 	    echo "FAIL: tests/platform/test_blk_virt_pump.c"; \
+	    status=1; \
+	fi; \
+	if gcc -I platform/include \
+	        -DAOS_REPO_ROOT='"$(ROOT_DIR)"' \
+	        tests/platform/test_virtio_blk_guest_path.c \
+	        -o $(BUILD_TMP_DIR)/test_virtio_blk_guest_path 2>&1 \
+	    && $(BUILD_TMP_DIR)/test_virtio_blk_guest_path; then \
+	    echo "PASS: tests/platform/test_virtio_blk_guest_path.c"; \
+	else \
+	    echo "FAIL: tests/platform/test_virtio_blk_guest_path.c"; \
 	    status=1; \
 	fi; \
 	echo ""; \
@@ -844,6 +867,7 @@ help:
 	@echo "                        (host suite + aarch64 + x86_64 GUEST_OS=none boot tests)"
 	@echo "  make test-guest-login Boot Ubuntu and FreeBSD to an interactive serial prompt"
 	@echo "  make test-guest-net   Boot buildroot and prove one packet through emulated virtio-net"
+	@echo "  make test-guest-blk   Boot buildroot and prove one request through emulated virtio-blk"
 	@echo ""
 	@echo "Guest images:"
 	@echo "  make fetch-guest GUEST_OS=ubuntu     Stage Ubuntu 26.04 assets in build/guest-images"
@@ -860,6 +884,7 @@ help:
 	@echo "  make run-tests        Run the seL4-target TAP test image in QEMU"
 	@echo "  make test-host        Host-only suite (alias of test-integration; NOT OS proof)"
 	@echo "  make test-guest-net   Guest packet proof: emulated virtio-net (buildroot)"
+	@echo "  make test-guest-blk   Guest I/O proof: emulated virtio-blk (buildroot)"
 	@echo "  make test-integration Run host-side contract/integration tests"
 	@echo "  make e2e              Run the default QEMU/guest/CC end-to-end suite"
 	@echo "  make e2e-dual-os      Run Ubuntu and FreeBSD guest E2E coverage"
@@ -882,5 +907,6 @@ help:
 	@echo "  make gate                          # full release gate, both arches"
 	@echo "  make test-guest-login QEMU_TEST_TIMEOUT=420"
 	@echo "  make test-guest-net QEMU_TEST_TIMEOUT=480"
+	@echo "  make test-guest-blk QEMU_TEST_TIMEOUT=480"
 	@echo "  cd ../agentos_gui && make run"
 	@echo ""

--- a/PLAN.md
+++ b/PLAN.md
@@ -19,13 +19,13 @@ binding) described the wrong I/O model. It is superseded by this document.
 | 1 | (done) | done | TCB page + constitution rewrite |
 | 2 | (done) | done (host-tested) | sDDF net under VMM (`virtio_mmio_net_init`), not QEMU passthrough |
 | 2b | `task_0d44a94246554eeabc8d5bc8e36ab6d7` | done | `make test-guest-net`: boot buildroot, enumerate IPA `0x0A010000`, pump one frame |
-| 3 | `task_892273845b0949ce8be59f70c02bf644` | ready | sDDF blk + emulated virtio-blk |
-| 4 | `task_9218737eb11a438b89552c599c25d012` | waiting on 3 | sDDF serial; one UART owner |
-| 5 | `task_7f6653b7dcc840b9ab7fa092685c9d57` | waiting on 3 | One VMM implementation; guest flavor is data |
-| 6 | `task_c03b1c0527de416fbcfcdfcb77787559` | waiting on 3 | Stop identity-mapping guest RAM for device DMA |
+| 3 | `task_892273845b0949ce8be59f70c02bf644` | done | `make test-guest-blk`: boot buildroot, enumerate IPA `0x0A020000`, pump one request |
+| 4 | `task_9218737eb11a438b89552c599c25d012` | ready | sDDF serial; one UART owner |
+| 5 | `task_7f6653b7dcc840b9ab7fa092685c9d57` | waiting on 4 | One VMM implementation; guest flavor is data |
+| 6 | `task_c03b1c0527de416fbcfcdfcb77787559` | waiting on 4 | Stop identity-mapping guest RAM for device DMA |
 | 7 | (done) | done (quarantine by docs) | Quarantine PD museum (no deletes this pass) |
 | 8 | (done) | done | Skills + Python HTML helpers |
-| 9 | `task_ec992e5743354a538d1c3235a2e2c0da` | waiting on 3 | Native agent services as virtualizer clients |
+| 9 | `task_ec992e5743354a538d1c3235a2e2c0da` | waiting on 4 | Native agent services as virtualizer clients |
 
 ## Proof policy (unchanged)
 
@@ -34,12 +34,13 @@ production IPC or I/O. OS-level claims require `make gate` (both target
 arches under QEMU) plus, for a device class, a guest I/O assertion through
 the virtualizer — not QEMU bus ownership.
 
-Dual-guest E2E remains a **guest-boot** gate until emulated virtio-net carries
-packets. Then it must assert I/O through `net_virt`, not QEMU bus ownership.
+Dual-guest E2E remains a **guest-boot** gate until emulated virtio-blk is
+the Ubuntu boot disk. Buildroot already proves I/O through `net_virt` and
+`blk_virt` (`make test-guest-net`, `make test-guest-blk`).
 
-Host tests for `aos_net_virt_pump` are a pre-filter. They are not proof that
-the guest sees the device. That proof is
-`task_0d44a94246554eeabc8d5bc8e36ab6d7`.
+Host tests for `aos_net_virt_pump` / `aos_blk_virt_pump` are a pre-filter.
+They are not proof that the guest sees the device. That proof is
+`make test-guest-net` / `make test-guest-blk`.
 
 ## Operator session (parallel; not I/O proof)
 
@@ -68,3 +69,16 @@ services is out of scope until inspect and serial attach exist.
    exists.
 4. Next: host virtio-net MMIO moves to a nic_drv PD; passthrough is removed
    from Ubuntu too; both guests share one `net_virt`.
+
+## First blk vertical slice (step 3)
+
+1. Guest IPA `0x0A020000` is an **emulated** virtio-mmio blk device (fault to VMM).
+2. Backend is sDDF-shaped queues + `aos_blk_virt_pump` (256 KB RAM disk).
+3. Buildroot overlay advertises **only** emulated net + emulated blk
+   (`make test-guest-blk`). Ubuntu overlays keep QEMU virtio-blk at
+   `0x0A000200` as a kill-dated boot-disk crutch; do not put emulated
+   blk before that node (it would steal `vda`).
+4. Linux `virtio_blk` probe + partition scan of LBA 0 is the I/O that
+   proves the pump. Do not set `root=` to the RAM disk.
+5. Payload copies in libvmm `block.c` still cast `desc.addr` as a host
+   pointer — identity map of guest RAM stays until step 6.

--- a/kernel/agentos-root-task/src/linux_vmm.c
+++ b/kernel/agentos-root-task/src/linux_vmm.c
@@ -1373,8 +1373,8 @@ void init(void)
 
     /*
      * Emulated virtio-blk at IPA 0x0A020000 (faults here, sDDF RAM pump).
-     * Not in the live guest DTB this pass — QEMU virtio-blk at 0x0A000200
-     * / IRQ 49 remains the boot disk (kill-dated crutch).
+     * Buildroot DTB advertises only this disk. Ubuntu still has QEMU
+     * virtio-blk at 0x0A000200 / IRQ 49 as the boot-disk crutch.
      */
     aos_vmm_virtio_blk_init();
 

--- a/libvmm/examples/simple/board/qemu_virt_aarch64/overlay.dts
+++ b/libvmm/examples/simple/board/qemu_virt_aarch64/overlay.dts
@@ -7,8 +7,10 @@
  * packaged initrd size. RAM / initrd IPA must match linux_vmm.c
  * (LINUX_GUEST_RAM_VADDR / GUEST_INIT_RAM_DISK_VADDR / GUEST_RAM_SIZE).
  *
- * Guest net is the emulated virtio-mmio at 0xa010000 only. QEMU virtio-net
- * at 0xa000000 is not in this tree so TX goes through aos_net_virt_pump.
+ * Guest I/O is emulated virtio-mmio only:
+ *   net  0xa010000  SPI 18 → INTID 50
+ *   blk  0xa020000  SPI 20 → INTID 52
+ * QEMU virtio-net/blk (0xa000000 / 0xa000200) are not in this tree.
  */
 / {
     /* Need to specify how much RAM the guest will have */
@@ -36,5 +38,14 @@
         reg = <0x00 0xa010000 0x00 0x1000>;
         interrupt-parent = <0x8001>;
         interrupts = <0x00 0x12 0x01>;
+    };
+
+    /* agentOS emulated virtio-blk (sDDF RAM pump, not QEMU). SPI 20 → INTID 52. */
+    virtio_mmio@a020000 {
+        compatible = "virtio,mmio";
+        dma-coherent;
+        reg = <0x00 0xa020000 0x00 0x1000>;
+        interrupt-parent = <0x8001>;
+        interrupts = <0x00 0x14 0x01>;
     };
 };

--- a/platform/README.md
+++ b/platform/README.md
@@ -24,9 +24,9 @@ QEMU virtio-mmio. Native agents attach to the same virtualizers as a VMM.
 Do not add `net_virt` to `IMAGES` / `system_desc` until a nic_drv owns the
 host NIC and the 2 MB region is a shared MR. This pass the VMM pumps locally.
 
-Do not add `blk_virt` to `IMAGES` / `system_desc`. Guest DTB still points at
-QEMU virtio-blk (`0x0A000200`) so E2E boot disk is unchanged. Emulated IPA
-is `0x0A020000` (SPI 20 / INTID 52).
+Do not add `blk_virt` to `IMAGES` / `system_desc`. Buildroot DTB advertises
+the emulated device at `0x0A020000` (SPI 20 / INTID 52). Ubuntu still points
+at QEMU virtio-blk (`0x0A000200`) so E2E boot disk is unchanged.
 
 ## Residual `guest_ram` identity map
 

--- a/platform/blk-virt/vmm_virtio_blk.c
+++ b/platform/blk-virt/vmm_virtio_blk.c
@@ -3,10 +3,11 @@
  * backend = sDDF queues + local aos_blk_virt_pump (RAM disk until blk_drv).
  *
  * QEMU virtio-mmio blk at 0x0A000200 remains a kill-dated passthrough
- * crutch (guest vda). This device is not in the live DTB this pass.
+ * crutch on Ubuntu (guest vda). Buildroot DTB uses only this device.
  */
 
 #include <libvmm/libvmm.h>
+#include <libvmm/virtio/config.h>
 #include <libvmm/virtio/block.h>
 #include <sddf/blk/queue.h>
 #include <sddf/blk/storage_info.h>
@@ -35,6 +36,9 @@ static aos_blk_virt_t           g_aos_virt;
 static aos_blk_virt_client_t    g_aos_client;
 static blk_queue_handle_t       g_queue;
 static int                      g_aos_blk_ready;
+static int                      g_aos_blk_probed;
+static int                      g_aos_blk_driver_ok;
+static int                      g_aos_blk_pumped;
 
 void aos_vmm_virtio_blk_init(void)
 {
@@ -89,11 +93,31 @@ void aos_vmm_virtio_blk_init(void)
 void aos_vmm_virtio_blk_after_fault(void)
 {
     virtio_queue_handler_t *vq;
+    uint32_t status;
+    uint32_t n;
 
     if (!g_aos_blk_ready) {
         return;
     }
-    (void)aos_blk_virt_pump(&g_aos_virt);
+
+    status = g_aos_blk.virtio_device.regs.Status;
+    if (!g_aos_blk_probed && (status & VIRTIO_CONFIG_S_ACKNOWLEDGE)) {
+        g_aos_blk_probed = 1;
+        LOG_VMM("emulated virtio-blk: guest probed IPA 0x%lx (status=0x%x)\n",
+                (unsigned long)AOS_VIRTIO_BLK_GUEST_IPA, (unsigned)status);
+    }
+    if (!g_aos_blk_driver_ok && (status & VIRTIO_CONFIG_S_DRIVER_OK)) {
+        g_aos_blk_driver_ok = 1;
+        LOG_VMM("emulated virtio-blk: guest DRIVER_OK virq %u capacity %u blocks\n",
+                (unsigned)AOS_VIRTIO_BLK_VIRQ,
+                (unsigned)AOS_BLK_DISK_BLOCKS);
+    }
+
+    n = aos_blk_virt_pump(&g_aos_virt);
+    if (!g_aos_blk_pumped && n > 0u) {
+        g_aos_blk_pumped = 1;
+        LOG_VMM("emulated virtio-blk: pumped %u request(s)\n", n);
+    }
 
     vq = &g_aos_blk.virtio_device.vqs[VIRTIO_BLK_DEFAULT_VIRTQ];
     if (!vq->ready || vq->virtq.avail == NULL) {

--- a/tests/platform/test_virtio_blk_guest_path.c
+++ b/tests/platform/test_virtio_blk_guest_path.c
@@ -1,0 +1,194 @@
+/*
+ * Guest virtio-blk path: DTB + VMM fault wiring.
+ *
+ * Host-only. Does not prove a Linux boot. It does assert:
+ *   1. Buildroot DTB advertises IPA 0xa020000 / SPI 20
+ *   2. That overlay has no QEMU virtio-blk at 0xa000200
+ *   3. linux_vmm pumps after fault_handle
+ *   4. VMM logs probed / DRIVER_OK / pumped
+ *
+ * gcc -I platform/include -DAOS_REPO_ROOT='"/path/"' \
+ *     tests/platform/test_virtio_blk_guest_path.c \
+ *     -o test_virtio_blk_guest_path
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <platform/blk_layout.h>
+#include <platform/net_layout.h>
+
+#ifndef AOS_REPO_ROOT
+#define AOS_REPO_ROOT "./"
+#endif
+
+static int g_failed;
+static int g_testno;
+
+static int tap_ok(int cond, const char *name)
+{
+    g_testno++;
+    if (cond) {
+        printf("ok %d - %s\n", g_testno, name);
+        return 0;
+    }
+    printf("not ok %d - %s\n", g_testno, name);
+    g_failed++;
+    return 1;
+}
+
+static char *read_file(const char *rel)
+{
+    char path[1024];
+    FILE *f;
+    long sz;
+    char *buf;
+    size_t n;
+
+    snprintf(path, sizeof(path), "%s%s", AOS_REPO_ROOT, rel);
+    f = fopen(path, "rb");
+    if (!f) {
+        printf("# cannot open %s\n", path);
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return NULL;
+    }
+    sz = ftell(f);
+    if (sz < 0 || sz > 4 * 1024 * 1024) {
+        fclose(f);
+        return NULL;
+    }
+    rewind(f);
+    buf = (char *)malloc((size_t)sz + 1u);
+    if (!buf) {
+        fclose(f);
+        return NULL;
+    }
+    n = fread(buf, 1, (size_t)sz, f);
+    fclose(f);
+    buf[n] = '\0';
+    return buf;
+}
+
+static int node_has(const char *node, const char *needle, size_t window)
+{
+    char tmp[512];
+    size_t n;
+
+    if (!node) {
+        return 0;
+    }
+    n = window;
+    if (n >= sizeof(tmp)) {
+        n = sizeof(tmp) - 1u;
+    }
+    memcpy(tmp, node, n);
+    tmp[n] = '\0';
+    return strstr(tmp, needle) != NULL;
+}
+
+static int src_contains(const char *rel, const char *needle)
+{
+    char *text = read_file(rel);
+    int ok;
+
+    if (!text) {
+        return 0;
+    }
+    ok = strstr(text, needle) != NULL;
+    free(text);
+    return ok;
+}
+
+static int src_contains_in_order(const char *rel, const char *first, const char *second)
+{
+    char *text = read_file(rel);
+    const char *a;
+    const char *b;
+    int ok;
+
+    if (!text) {
+        return 0;
+    }
+    a = strstr(text, first);
+    b = a ? strstr(a, second) : NULL;
+    ok = a != NULL && b != NULL;
+    free(text);
+    return ok;
+}
+
+static int dts_emulated_blk_ok(const char *rel)
+{
+    char *text = read_file(rel);
+    const char *node;
+    int ok;
+
+    if (!text) {
+        return 0;
+    }
+    node = strstr(text, "virtio_mmio@a020000");
+    ok = node
+      && node_has(node, "compatible = \"virtio,mmio\"", 400)
+      && node_has(node, "0xa020000", 400)
+      && node_has(node, "0x1000", 400)
+      && node_has(node, "0x14", 400);
+    free(text);
+    return ok;
+}
+
+static int test_abi(void)
+{
+    int ok = (AOS_VIRTIO_BLK_GUEST_IPA == 0x0A020000UL)
+          && (AOS_VIRTIO_BLK_MMIO_SIZE == 0x1000UL)
+          && (AOS_VIRTIO_BLK_VIRQ == 52u)
+          && (AOS_VIRTIO_BLK_DTB_SPI == 20u)
+          && (AOS_VIRTIO_BLK_VIRQ == 32u + AOS_VIRTIO_BLK_DTB_SPI)
+          && (AOS_VIRTIO_BLK_GUEST_IPA != 0x0A000000UL)
+          && (AOS_VIRTIO_BLK_GUEST_IPA != 0x0A000200UL)
+          && (AOS_VIRTIO_BLK_GUEST_IPA != AOS_VIRTIO_NET_GUEST_IPA)
+          && (AOS_VIRTIO_BLK_GUEST_IPA >= 0x0A000000UL + 32u * 0x200u);
+    return tap_ok(ok, "abi IPA 0x0A020000 IRQ 52 (SPI 20) outside QEMU page");
+}
+
+int main(void)
+{
+    printf("TAP version 14\n");
+    printf("# suite: virtio_blk_guest_path (host pre-filter, not guest-boot proof)\n");
+
+    (void)test_abi();
+    (void)tap_ok(dts_emulated_blk_ok(
+                     "libvmm/examples/simple/board/qemu_virt_aarch64/overlay.dts"),
+                 "DTB buildroot overlay.dts has virtio_mmio@a020000");
+    (void)tap_ok(!src_contains("libvmm/examples/simple/board/qemu_virt_aarch64/overlay.dts",
+                               "virtio_mmio@a000200"),
+                 "buildroot overlay.dts has no QEMU virtio-blk at 0xa000200");
+    (void)tap_ok(src_contains("kernel/agentos-root-task/src/linux_vmm.c",
+                              "aos_vmm_virtio_blk_init"),
+                 "linux_vmm calls aos_vmm_virtio_blk_init");
+    (void)tap_ok(src_contains_in_order(
+                     "kernel/agentos-root-task/src/linux_vmm.c",
+                     "fault_handle(vcpu_id, msginfo)",
+                     "aos_vmm_virtio_blk_after_fault()"),
+                 "linux_vmm: fault_handle then virtio-blk after_fault");
+    (void)tap_ok(src_contains("platform/blk-virt/vmm_virtio_blk.c",
+                              "emulated virtio-blk: guest probed"),
+                 "VMM logs guest virtio-blk probe");
+    (void)tap_ok(src_contains("platform/blk-virt/vmm_virtio_blk.c",
+                              "emulated virtio-blk: guest DRIVER_OK"),
+                 "VMM logs guest virtio-blk DRIVER_OK");
+    (void)tap_ok(src_contains("platform/blk-virt/vmm_virtio_blk.c",
+                              "emulated virtio-blk: pumped"),
+                 "VMM logs first pumped blk request");
+
+    printf("1..%d\n", g_testno);
+    if (g_failed) {
+        printf("# %d failed (host pre-filter only)\n", g_failed);
+        return 1;
+    }
+    printf("# all virtio_blk_guest_path tests passed (not boot-proven)\n");
+    return 0;
+}

--- a/xtask/src/cmd_test.rs
+++ b/xtask/src/cmd_test.rs
@@ -35,14 +35,14 @@ const VIBEOS_DEV_BLOCK: u32 = 1 << 2;
 pub fn run(args: &TestArgs) -> anyhow::Result<()> {
     let repo_root = repo_root()?;
 
-    if args.assert_emulated_net {
+    if args.assert_emulated_net || args.assert_emulated_blk {
         anyhow::ensure!(
             args.board == "qemu_virt_aarch64",
-            "--assert-emulated-net requires --board qemu_virt_aarch64"
+            "--assert-emulated-net/--assert-emulated-blk require --board qemu_virt_aarch64"
         );
         anyhow::ensure!(
             args.guest_os != "none",
-            "--assert-emulated-net needs a real guest (buildroot or ubuntu); GUEST_OS=none is a stub VMM"
+            "--assert-emulated-net/--assert-emulated-blk need a real guest (buildroot or ubuntu); GUEST_OS=none is a stub VMM"
         );
     }
 
@@ -103,6 +103,12 @@ pub fn run(args: &TestArgs) -> anyhow::Result<()> {
             log_path.display()
         );
         wait_for_emulated_net(&log_path, Duration::from_secs(args.timeout_secs))
+    } else if args.assert_emulated_blk {
+        println!(
+            "[xtask:test] Waiting for emulated virtio-blk guest proof in {}...",
+            log_path.display()
+        );
+        wait_for_emulated_blk(&log_path, Duration::from_secs(args.timeout_secs))
     } else {
         match args.guest_os.as_str() {
         "ubuntu" => {
@@ -660,6 +666,65 @@ const EMU_NET_GUEST_ANY: &[&str] = &[
     "02:00:00:00:00:01",
     "Sending DHCP requests",
 ];
+
+const EMU_BLK_REQUIRED: &[&str] = &[
+    "emulated virtio-blk: guest probed",
+    "emulated virtio-blk: guest DRIVER_OK",
+    "emulated virtio-blk: pumped",
+];
+
+const EMU_BLK_GUEST_ANY: &[&str] = &[
+    "0a020000.virtio_mmio",
+    "a020000.virtio_mmio",
+    "virtio_blk",
+    "[vda]",
+];
+
+fn wait_for_emulated_blk(log_path: &Path, timeout: Duration) -> anyhow::Result<String> {
+    let start = Instant::now();
+    let mut file = std::fs::File::open(log_path).context("failed to open log file")?;
+    let mut offset: u64 = 0;
+    let mut accumulated = String::new();
+
+    loop {
+        if start.elapsed() >= timeout {
+            let missing: Vec<&str> = EMU_BLK_REQUIRED
+                .iter()
+                .copied()
+                .filter(|m| !accumulated.contains(m))
+                .collect();
+            let guest_ok = EMU_BLK_GUEST_ANY
+                .iter()
+                .any(|m| accumulated.contains(m));
+            anyhow::bail!(
+                "emulated virtio-blk proof timeout after {}s; missing VMM markers {:?}; guest IPA/disk observed={}",
+                timeout.as_secs(),
+                missing,
+                guest_ok
+            );
+        }
+
+        file.seek(SeekFrom::Start(offset))?;
+        let mut raw = Vec::new();
+        let bytes_read = file.read_to_end(&mut raw)?;
+        if bytes_read > 0 {
+            offset += bytes_read as u64;
+            accumulated.push_str(&String::from_utf8_lossy(&raw));
+
+            let vmm_ok = EMU_BLK_REQUIRED
+                .iter()
+                .all(|m| accumulated.contains(m));
+            let guest_ok = EMU_BLK_GUEST_ANY
+                .iter()
+                .any(|m| accumulated.contains(m));
+            if vmm_ok && guest_ok {
+                return Ok("emulated virtio-blk: guest probed + DRIVER_OK + pumped + guest IPA/disk".to_string());
+            }
+        }
+
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}
 
 fn wait_for_emulated_net(log_path: &Path, timeout: Duration) -> anyhow::Result<String> {
     let start = Instant::now();

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -38,6 +38,9 @@ pub struct TestArgs {
     /// Host tests are not this proof. GUEST_OS=none is a stub VMM.
     #[arg(long)]
     pub assert_emulated_net: bool,
+    /// Require emulated virtio-blk probe + DRIVER_OK + a pumped request.
+    #[arg(long)]
+    pub assert_emulated_blk: bool,
 }
 
 #[derive(clap::Args)]


### PR DESCRIPTION
## Summary
- Stacks on #108. Buildroot DTB advertises emulated virtio-blk at IPA `0x0A020000` (SPI 20 / INTID 52); linux_vmm pumps sDDF RAM-disk requests after MMIO faults.
- `make test-guest-blk` boots buildroot and requires `guest probed` + `DRIVER_OK` + `pumped` plus a guest `virtio_blk` / `[vda]` / `a020000.virtio_mmio` line.
- Ubuntu still boots from QEMU virtio-blk at `0x0A000200`. That node stays first; emulated blk is not enabled on Ubuntu overlays (would steal `vda`).

## Test plan
- [x] `make test-host` (includes `test_virtio_blk_guest_path.c`)
- [x] `make test-guest-blk QEMU_TEST_TIMEOUT=480` — probed IPA `0xa020000`, DRIVER_OK virq 52, pumped 1 request, guest `[vda]` 64×4K
- [ ] CI job `Guest virtio-blk I/O proof (buildroot)`
- [ ] Do not merge until #108 lands (or retarget to `main` after it does)