### PR TITLE
Roadmap Debian integration and official Omarchy qualification

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,7 +30,9 @@ dual-guest SSH
       |                                  ^
       +---- 0.2 release workflow --------+
 
-0.3 Debian integration baseline -- 0.3 framebuffer target proof
+0.3 declarative guest profiles -> 0.3 Debian integration baseline
+              |                              |
+              |                    0.3 framebuffer target proof
               |                              |
               +------------------------------+-- 0.3 Omarchy compatibility ledger
       |
@@ -111,6 +113,16 @@ same agentOS-owned VirtIO paths. No v0.2 receipt or historical claim is
 rewritten. The initial artifact decision and checksums are recorded in
 `docs/linux-guest-baseline.md`.
 
+Guest identity must also stop selecting target implementations. Versioned
+TOML source profiles are validated and compiled by the Rust host tooling into
+a compact, bounded runtime manifest. The target selects generic boot protocols
+and device capabilities from that manifest; artifact acquisition, console
+matchers, provisioning, and test recipes remain host-only profile data. If a
+recipe needs more than static fields, it uses a finite declarative state
+machine interpreted by Rust host tooling, never an arbitrary interpreter in a
+VMM or device-service PD. Debian and Omarchy extend reusable Linux/Arch
+profiles rather than introducing new VMM implementations.
+
 Linux baseline acceptance evidence:
 
 - the dated Debian image, checksum manifest, provisioning input, extracted
@@ -126,6 +138,10 @@ Linux baseline acceptance evidence:
 
 MAC work:
 
+- `task_7f6653b7dcc840b9ab7fa092685c9d57` - collapse Linux and FreeBSD onto
+  one flavor-driven VMM implementation.
+- `task_a1d4e9d734e246c4a3807d614c2a6dc7` - compile declarative guest source
+  profiles into a guest-neutral runtime manifest and host-side test recipes.
 - `task_26e8b1157ffe449483d2fe1c44f2a8be` - replace Ubuntu live media with the
   pinned Debian integration guest after parity is proven.
 
@@ -182,7 +198,6 @@ Acceptance evidence:
 
 MAC work:
 
-- `task_7f6653b7dcc840b9ab7fa092685c9d57` — make guest flavor data-driven.
 - `task_ede60b058fc745d296bad77044a57420` — implement VMX guest execution.
 - `task_5870ef2f51974ffe95099c3032d0f077` — implement UEFI and ACPI guest
   boot.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ changing the dependency order below.
 | Release | Theme | Required outcome |
 | --- | --- | --- |
 | **0.2** | Network desktop proof and release discipline | Ubuntu exposes a real desktop session over the already authenticated network path; releases become exact-revision, evidence-bound transitions; the first systems/security narrative is grounded in retained evidence. |
-| **0.3** | Guest graphics foundation | The canonical framebuffer is live on target, generic virtio-gpu plus virtio-input virtualizers drive an AArch64 guest without host-device passthrough, and the official Omarchy compatibility ledger is kept current. |
+| **0.3** | Reproducible Linux and guest graphics | A pinned Debian guest replaces Ubuntu as the cross-architecture integration baseline, the canonical framebuffer is live on target, generic virtio-gpu plus virtio-input virtualizers drive an AArch64 guest without host-device passthrough, and the official Omarchy compatibility ledger is kept current. |
 | **0.4** | x86 guest foundation | A real VMX-backed x86_64 VMM boots Linux and reuses canonical net, block, and console services with isolated GPA translation. |
 | **0.5** | Persistent x86 desktop platform | A pinned Arch Linux x86_64 guest installs through UEFI, reboots from writable storage, reaches key-only SSH, and runs a Hyprland-class compositor through canonical graphics and input. |
 | **0.6** | Official Omarchy qualification | A reproducible official Omarchy artifact installs to encrypted persistent storage, reaches its normal Hyprland desktop, and survives evidence-bound update and recovery gates. |
@@ -30,7 +30,9 @@ dual-guest SSH
       |                                  ^
       +---- 0.2 release workflow --------+
 
-0.3 framebuffer target proof ----- 0.3 Omarchy compatibility ledger
+0.3 Debian integration baseline -- 0.3 framebuffer target proof
+              |                              |
+              +------------------------------+-- 0.3 Omarchy compatibility ledger
       |
       v
 0.3 virtio-gpu + virtio-input -------------------+
@@ -91,7 +93,43 @@ MAC work:
   evidence-backed systems/security narrative after the proof and release gate
   are true.
 
-## 0.3 — Guest graphics foundation
+## 0.3 — Reproducible Linux and guest graphics
+
+Ubuntu was the v0.2 proof-of-life guest. Its retained evidence remains valid,
+but it is not the long-term Linux acceptance baseline. The distribution roles
+from v0.3 onward are deliberately separate:
+
+- Buildroot remains the smallest deterministic per-device and boot proof.
+- A pinned Debian stable generic image is the cross-architecture integration
+  guest for net, block, console, lifecycle, provisioning, and release gates.
+- FreeBSD remains the second-kernel compatibility guest.
+- Official Arch Linux x86_64 is the desktop-platform precursor in v0.5.
+- Official Omarchy is qualified only after that reusable platform passes.
+
+Debian replaces Ubuntu in required gates only after it reaches parity on the
+same agentOS-owned VirtIO paths. No v0.2 receipt or historical claim is
+rewritten. The initial artifact decision and checksums are recorded in
+`docs/linux-guest-baseline.md`.
+
+Linux baseline acceptance evidence:
+
+- the dated Debian image, checksum manifest, provisioning input, extracted
+  boot artifacts, and conversion to agentOS block media are reproducible;
+- AArch64 reaches key-only SSH through agentOS VirtIO net, block, and console
+  without QEMU device passthrough or a guest-specific backend;
+- the boot contract is documented and tested rather than assuming that the
+  image's firmware environment exists in the current AArch64 VMM;
+- cold-boot time and failure diagnostics are retained beside the Ubuntu v0.2
+  measurement before Ubuntu leaves required gates;
+- the same Debian release and provisioning contract extend to amd64 when the
+  v0.4 x86 VMM is ready.
+
+MAC work:
+
+- `task_26e8b1157ffe449483d2fe1c44f2a8be` - replace Ubuntu live media with the
+  pinned Debian integration guest after parity is proven.
+
+### Guest graphics foundation
 
 This release turns display claims into an agentOS-owned path:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ changing the dependency order below.
 | Release | Theme | Required outcome |
 | --- | --- | --- |
 | **0.2** | Network desktop proof and release discipline | Ubuntu exposes a real desktop session over the already authenticated network path; releases become exact-revision, evidence-bound transitions; the first systems/security narrative is grounded in retained evidence. |
-| **0.3** | Guest graphics foundation | The canonical framebuffer is live on target, and generic virtio-gpu plus virtio-input virtualizers drive an AArch64 guest without host-device passthrough. |
+| **0.3** | Guest graphics foundation | The canonical framebuffer is live on target, generic virtio-gpu plus virtio-input virtualizers drive an AArch64 guest without host-device passthrough, and the official Omarchy compatibility ledger is kept current. |
 | **0.4** | x86 guest foundation | A real VMX-backed x86_64 VMM boots Linux and reuses canonical net, block, and console services with isolated GPA translation. |
 | **0.5** | Persistent x86 desktop platform | A pinned Arch Linux x86_64 guest installs through UEFI, reboots from writable storage, reaches key-only SSH, and runs a Hyprland-class compositor through canonical graphics and input. |
 | **0.6** | Official Omarchy qualification | A reproducible official Omarchy artifact installs to encrypted persistent storage, reaches its normal Hyprland desktop, and survives evidence-bound update and recovery gates. |
@@ -115,7 +115,8 @@ MAC work:
 - `task_cefc0f77327d4245ab9feb132cd1eb57` — implement guest virtio-gpu and
   virtio-input.
 - `task_93ddbd0f497e4209a162e0f5527fc7cf` — maintain an evidence ledger for
-  official Omarchy architecture, artifacts, repositories, and requirements.
+  official Omarchy architecture, artifacts, repositories, and requirements;
+  the maintained snapshot is `docs/omarchy-compatibility.md`.
 
 ## 0.4 — x86 guest foundation
 
@@ -195,6 +196,8 @@ Acceptance evidence:
 - injected keyboard and pointer input plus a non-uniform captured frame;
 - successful pinned update and reboot;
 - snapshot-backed rollback or recovery from an injected failed update;
+- retained cold-boot timing from vCPU start to key-only SSH and to the first
+  non-uniform compositor frame, compared with the pinned Ubuntu desktop proof;
 - exact guest release identity recorded in release evidence.
 
 MAC work:

--- a/docs/linux-guest-baseline.md
+++ b/docs/linux-guest-baseline.md
@@ -1,0 +1,82 @@
+# Linux Guest Baseline
+
+Status: accepted roadmap decision, implementation pending
+
+Snapshot date: 2026-09-08
+
+## Decision
+
+agentOS uses different Linux guests for different evidence:
+
+| Guest | Role | Why |
+| --- | --- | --- |
+| Buildroot | Minimal device proof | Small, deterministic, and controlled by the repository. |
+| Debian stable | Canonical integration and release guest | Official arm64 and amd64 generic images share one stable release and standard kernel. |
+| Arch Linux x86_64 | Desktop-platform precursor | Matches Omarchy's package ecosystem without coupling platform bring-up to Omarchy. |
+| Omarchy x86_64 | Product qualification guest | Exercises the official installer, Hyprland session, encryption, update, and recovery paths. |
+
+Ubuntu remains the historical v0.2 proof-of-life guest. It is removed from
+required gates only after Debian proves equivalent net, block, console,
+lifecycle, provisioning, and authenticated SSH behavior. Existing Ubuntu
+evidence and release receipts are not rewritten.
+
+Arch Linux ARM is not the canonical AArch64 guest. It is a separately produced
+rolling distribution rather than the same official artifact stream used for
+Arch Linux x86_64, which weakens cross-architecture provenance and release
+reproducibility.
+
+## Initial Debian artifact pin
+
+The initial implementation target is Debian 13 stable's dated generic image
+build `20260831-2587`. Use `generic`, not `genericcloud`: the generic image
+retains the standard kernel and broad driver set. Do not consume the moving
+`latest` aliases in release evidence.
+
+Base URL:
+
+```text
+https://cloud.debian.org/images/cloud/trixie/20260831-2587/
+```
+
+Pinned images and SHA-512 digests:
+
+```text
+debian-13-generic-arm64-20260831-2587.qcow2
+27287048285224e662722b54c77849c9bd1a2fd60ccea5f2e75c644fbd638fad7e32a97e8e3d628c8bbfdb9cf757951c8300f3c21758647c8906359d9c892b42
+
+debian-13-generic-amd64-20260831-2587.qcow2
+5a069019420fb9441ad4f8004c661fadb747edd5662ca54a17c8f923dee7d717e21dbdaa4ba72d6fce7f920e0217f0a9af382298a7d46ed4bc9dc33ac19181b6
+```
+
+The source of record for the digests is the `SHA512SUMS` file in the dated
+directory. A later implementation may advance this pin through a reviewed
+change that updates the artifact, manifest, and retained boot evidence
+together.
+
+## Delivery contract
+
+The Debian artifact is guest media, not a reason to map QEMU devices into the
+guest. The implementation must:
+
+1. Fetch the exact dated artifact and verify its SHA-512 digest before use.
+2. Reproducibly convert or expand qcow2 content into media served by the
+   agentOS block path.
+3. Extract or otherwise supply the kernel, initrd, and device description
+   required by the existing AArch64 boot contract. Do not assume guest UEFI is
+   already present.
+4. Provide deterministic cloud-init NoCloud data or an equivalently audited
+   pre-provisioning step, with key-only SSH and no default password.
+5. Boot using only emulated VirtIO devices backed by agentOS-owned services.
+6. Prove ordered network traffic, persistent block behavior, console I/O,
+   authenticated SSH, teardown, and a second clean boot.
+7. Retain cold-boot timings from vCPU start to login and authenticated SSH,
+   compared on the same runner with the Ubuntu v0.2 proof.
+8. Reuse the same release, provisioning contract, and acceptance assertions
+   on amd64 once the v0.4 VMM supplies the architecture-specific boot path.
+
+## Promotion rule
+
+Debian becomes the required integration guest only when the full parity suite
+passes at one immutable revision. Until then, Ubuntu remains the required v0.2
+gate and Debian is additive. Buildroot continues to own low-level device proof
+regardless of the integration distribution.

--- a/docs/omarchy-compatibility.md
+++ b/docs/omarchy-compatibility.md
@@ -1,0 +1,109 @@
+# Omarchy Compatibility Ledger
+
+This ledger is the upstream compatibility input to the agentOS Omarchy
+roadmap. It records facts about an official artifact separately from agentOS
+implementation choices and unproven expectations. An entry here is not a
+support claim. `docs/ROADMAP.md` defines the gates for such a claim.
+
+Current snapshot: **2026-09-08**, upstream **Omarchy v4.0.3**.
+
+## Pinned official artifact
+
+| Field | Pinned value | Evidence |
+| --- | --- | --- |
+| Release | `v4.0.3`, published 2026-09-08 | [upstream release](https://github.com/omacom/omarchy/releases/tag/v4.0.3) |
+| Runtime tag commit | `0534987009061cbe2dacdde4ad564092ab698d12` | [tagged commit](https://github.com/omacom/omarchy/commit/0534987009061cbe2dacdde4ad564092ab698d12) |
+| Installation media | `https://iso.omarchy.org/omarchy-4.0.3.iso` | release body and [ISO project](https://github.com/omacom/omarchy-iso) |
+| ISO SHA-256 | `03d60bc74306dca51f96e1a84b690871d8d606826b260edd0208962da8507d14` | release body and adjacent `.sha256` sidecar |
+| ISO size | `6,260,654,080` bytes | HTTP object metadata |
+| ISO source observed | `a23f8d464dcb0616a61bfaa8026e23d0533da209` on `quattro` | [observed ISO commit](https://github.com/omacom/omarchy-iso/commit/a23f8d464dcb0616a61bfaa8026e23d0533da209) |
+
+The upstream release receipt does not bind the published ISO to an exact
+`omarchy-iso` source commit. The observed ISO commit is therefore research
+context, not a claimed build provenance link. agentOS must retain the ISO
+bytes and verify the published digest; it must not rebuild an artifact and
+call that the official image.
+
+## Upstream compatibility facts
+
+| Area | Official v4.0.3 fact | Consequence for agentOS |
+| --- | --- | --- |
+| Architecture | The ISO profile sets `arch="x86_64"`. The stable Arch and Omarchy repositories serve `x86_64`; their corresponding `aarch64` database URLs returned 404 at this snapshot. | Official qualification waits for the 0.4 x86 VMM. Community AArch64 ports do not satisfy it. |
+| Firmware | The ISO declares BIOS and UEFI boot modes. Upstream's VM example uses Q35 plus OVMF and no pre-enrolled keys. | The agentOS qualification profile deliberately uses its canonical UEFI/ACPI path. BIOS support is not required for the claim. |
+| Installation | The ISO is the only upstream-supported installation path. It contains an offline package mirror and supports a second `cidata` drive for unattended installation. | Model the ISO and `cidata` as read-only block devices and the destination as a distinct persistent writable device. Prefer unattended installation for repeatable gates. |
+| Storage | Full-disk and free-space installs are supported. Encryption is the default. Current installs use LUKS, Btrfs subvolumes, a swap file, snapshots, and an EFI system partition. | Virtio block must correctly implement flush, discard policy, persistence, reboot, and multiple devices before the installer gate. No host filesystem shortcuts. |
+| Network | NetworkManager with DHCP is enabled. An unattended config containing `authorized_keys` enables SSH and opens its firewall rule. | Canonical virtio-net can provide the install and post-boot path. The support gate remains key-only SSH even though upstream leaves password SSH at the distribution default. |
+| Desktop | Omarchy installs Hyprland, Quickshell, SDDM, UWSM, `xdg-desktop-portal-hyprland`, PipeWire/WirePlumber tools, and GPU-sensitive applications. Upstream installs Vulkan drivers after detecting a supported PCI GPU vendor. | Wayland stays entirely inside the hostile guest. agentOS must provide standards-visible DRM/KMS graphics and evdev input through virtio-gpu and virtio-input; it does not implement the Wayland protocol. Quickshell and representative GL/Vulkan clients are part of the eventual proof. |
+| Graphics | Upstream's VM example uses virtio VGA. Its acceptance harness validates the real SDDM and graphical session with QMP screenshots and virtual keystrokes. | Start with virtio-gpu 2D scanout, but do not assume that scanout alone qualifies the full desktop. Record the renderer and acceleration mode, exercise buffer sharing, and require a non-uniform captured frame. |
+| Input | The installer, encryption prompt, SDDM, Hyprland, and desktop acceptance all require keyboard input; normal desktop qualification also requires a pointer. | Provide generic virtio-input keyboard and pointer devices. Console injection is not substitute evidence. |
+| CPU and RAM | Upstream publishes a Proxmox example with host CPU, 4 vCPUs, 8 GiB RAM, and a 40 GiB disk, but does not label those values as universal minimums. | Use these as the initial test profile, not a support minimum. Fail closed if the requested x86 profile cannot be allocated, then measure and document a qualified floor. |
+| Secure boot and TPM | The current getting-started instructions require Secure Boot and TPM to be disabled for installation. | Do not expose either as enabled in the first qualification profile. Future support is a distinct claim. |
+| Updates | Stable installations use Omarchy packages, a stable Omarchy Arch mirror, and the stable channel. | Pin the repository state used by the install/update test, retain before/after package identity, inject a failed update, and prove snapshot recovery. |
+
+Primary upstream references for this snapshot:
+
+- [Omarchy v4.0.3 release](https://github.com/omacom/omarchy/releases/tag/v4.0.3)
+- [Omarchy ISO README at the observed source revision](https://github.com/omacom/omarchy-iso/blob/a23f8d464dcb0616a61bfaa8026e23d0533da209/README.md)
+- [x86_64 ISO profile at the observed source revision](https://github.com/omacom/omarchy-iso/blob/a23f8d464dcb0616a61bfaa8026e23d0533da209/configs/profiledef.sh)
+- [Omarchy getting-started manual at v4.0.3](https://github.com/omacom/omarchy/blob/v4.0.3/manual/02-getting-started.md)
+- [Omarchy package set at v4.0.3](https://github.com/omacom/omarchy/blob/v4.0.3/install/omarchy-base.packages)
+- [Omarchy GPU detection at v4.0.3](https://github.com/omacom/omarchy/blob/v4.0.3/install/hardware/vulkan.sh)
+- [Omarchy update-channel manual at v4.0.3](https://github.com/omacom/omarchy/blob/v4.0.3/manual/30-updates.md)
+
+## agentOS delivery sequence
+
+The smallest truthful path is:
+
+1. Keep this ledger current before each Omarchy-related milestone. A changed
+   architecture, repository, installer, desktop stack, or artifact digest is
+   a gate input, not background churn.
+2. Complete generic framebuffer, virtio-gpu, and virtio-input work on the
+   existing AArch64 guest. This validates the device model without claiming
+   Omarchy support.
+3. Boot a minimal x86_64 Linux guest through the data-driven VMX, UEFI, ACPI,
+   interrupt, GPA, and canonical-device paths.
+4. Install pinned vanilla Arch to persistent storage and qualify SSH,
+   DRM/KMS, input, and a Hyprland-class compositor.
+5. Attach the official Omarchy ISO plus generated `cidata`, install to an
+   isolated writable disk, reboot, and prove key-only SSH.
+6. Prove the unmodified Omarchy SDDM, Hyprland, and Quickshell session with
+   keyboard and pointer input, a captured non-uniform frame, and representative
+   GL/Vulkan clients.
+7. Pin and test one update, inject a failed update, and demonstrate recovery
+   from retained Btrfs snapshot evidence.
+
+## Boot-time hypothesis and measurement
+
+Omarchy upstream reports faster and potentially sub-minute **installation**;
+that is not evidence of faster boot. The expected guest-development advantage
+is a hypothesis until agentOS measures it.
+
+Every persistent Arch and Omarchy run must retain monotonic timestamps for:
+
+- vCPU start to firmware entry;
+- vCPU start to key-only SSH readiness;
+- vCPU start to SDDM readiness; and
+- vCPU start to the first non-uniform compositor frame.
+
+Compare cold and warm Omarchy runs with the pinned Ubuntu desktop proof on the
+same agentOS revision and resource profile. Do not set a release threshold
+until the first measurements show a stable distribution; thereafter, regress
+the qualified percentile and record artifact, vCPU, RAM, storage, renderer,
+and acceleration mode with every result.
+
+## Known gaps at this snapshot
+
+- No VMX-backed x86_64 guest execution exists in agentOS yet.
+- No agentOS UEFI/ACPI path exists for a full x86 guest yet.
+- Writable guest storage has not been qualified for an installer, LUKS,
+  Btrfs, flush, reboot, or snapshot recovery.
+- Virtio-gpu and virtio-input virtualizers and their canonical target services
+  are roadmap work, not current behavior.
+- The minimum renderer needed for unmodified Hyprland plus Quickshell is not
+  yet measured. A software-rendered bring-up may accelerate development but
+  cannot silently become the final support profile.
+- The official release page supplies an ISO digest but not an exact ISO source
+  revision or package-manifest digest. Those provenance gaps must be retained
+  explicitly in release evidence.
+- Upstream contains AArch64 planning and community experiments, but the
+  v4.0.3 official image and repositories pinned above are x86_64-only.


### PR DESCRIPTION
## Summary

- add a dated compatibility ledger for official Omarchy architecture, installer media, repositories, runtime source, firmware, storage, graphics/input, and recovery requirements
- make the x86 path explicit: VMX/UEFI first, pinned vanilla Arch plus a Hyprland-class compositor next, official Omarchy qualification only after the reusable platform passes
- keep Wayland wholly inside the hostile guest; agentOS supplies emulated virtio-gpu and virtio-input backed by native display/input services
- replace Ubuntu as the future canonical integration guest with a pinned Debian stable `generic` image after v0.2 parity, while keeping Buildroot for device proofs and FreeBSD for second-kernel coverage
- pin the initial Debian 13 arm64 and amd64 artifacts and SHA-512 digests, and define their media conversion, boot, provisioning, authenticated SSH, lifecycle, and boot-time evidence contract

## Distribution roles

- Buildroot: deterministic low-level device proof
- Debian stable: cross-architecture integration and release acceptance
- FreeBSD: independent kernel compatibility
- Arch Linux x86_64: desktop-platform and Omarchy precursor
- Omarchy x86_64: official installer, desktop, encryption, update, and recovery qualification

Ubuntu remains valid v0.2 evidence and leaves required gates only after Debian passes equivalent agentOS-owned VirtIO net, block, console, lifecycle, and SSH tests.

## Evidence

- `make test-host`
- `git diff --check`
- official artifact URLs and checksum manifests captured in the two compatibility documents

Dispatch remains paused. The roadmap work is staged in MAC rather than released to an unattended fleet.
