### PR TITLE
release: prepare v0.2.0 OS evidence bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,134 +5,70 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-09-09
+
 ### Security
-- EventBus topic ownership prevents PD squatting (publish_as + Unauthorized error)
-- EventBus per-subscriber queue cap (256 events) for backpressure
-- CapabilitySet delegation chain recorded with SHA-256 attestation hash
-- WASM linear memory bounds capped at 4MB; host import bounds checked
-- SpawnServer ELF images hashed (SHA-256) and verified by app_slot on load
-- NameServer gated lookup (OP_NS_LOOKUP_GATED) with badge authorization
-- VFS path normalization: `..` resolution and inode cycle detection
-- WASM capability manifest SHA-256 verification before cap grants
-- Capability class annotations on all shared memory regions
-- ChaCha20-Poly1305 encrypted IPC between mesh PDs (`2adbe15`)
-- Ed25519 WASM module verification before slot allocation (`ec58583`, `f3f327e`)
-- cap_audit_log PD: seL4 capability grant/revoke audit trail (`1cfffeb`)
-- Boot integrity measurement chain wired into SDF CI gate (`4ae5153`)
-- net_isolator PD: per-agent outbound network firewall via seL4 capability model (`2489ef3`)
-- Priority inheritance for passive PD PPC calls to prevent inversion (`f91f026`)
-- Watchdog hardening with 4-tier escalation and restart throttling (`732c2ff`)
-- Capability attenuation: OP_CAP_ATTENUATE for sub-delegation (`f3bb3f3`)
 
-### Features
-- Evidence-bound release workflow with plan, prepare, check, publish, and
-  remote-asset verification phases
-- Authenticated Ubuntu desktop gate with deterministic RFB frame evidence and
-  packet capture
-- One-command dual-guest showcase: `make demo` boots Ubuntu and FreeBSD
-  concurrently, proves key-only SSH to both, and retains them for manual
-  sessions; `make demo-test` provides the non-interactive acceptance gate.
-- `make setup` installs host dependencies and the shared Microkit SDK;
-  `make demo-smoke` provides a fast host-only preflight.
-- Board abstraction system: `BOARD_NAME` variable selects `boards/<name>/board.mk`; auto-derived from `TARGET_ARCH` for QEMU dev builds (`make build BOARD_NAME=rpi5`, `make build BOARD_NAME=intel-nuc`)
-- boards/rpi5: full AArch64 system manifest with PL011 UART, GIC IRQ, linux_vmm native stub
-- boards/intel-nuc: x86_64 system manifest with NS16550 UART at MMIO 0xFE034000; console_shell ring-buffer RX path (Microkit 2.1.0 lacks x86_64 IRQ support)
-- linux_vmm native stub (`LINUX_VMM_NATIVE_STUB`): bare-metal AArch64 boards compile linux_vmm as a no-op PD without libvmm's QEMU-specific GIC addresses
-- console_shell PD added to aarch64 QEMU, rpi5, and intel-nuc system manifests (priority 49, channels 41/42)
-- Bridge: `GET /api/agentos/console/stream` SSE endpoint — streams serial log lines live with optional `?slot=N` filter and historical replay on connect
-- Bridge: `POST /api/agentos/console/cmd` — injects commands to seL4 console_shell via QEMU serial socket
-- Bridge: `GET /api/agentos/console/vms` — seL4 VM lifecycle registry distinct from QEMU-hosted VMs
-- Bridge serial reader: intercepts `\x01VM:start/stop:id` escape sequences from console_shell PD to track seL4 VM state
-- Multi-pane dashboard: Topology, Console, Profiler, Agents, Images, Docs panels (`270a825`)
-- Collapsible sidebar with mini topology SVG + system stat chips
-- Full SVG topology graph with live CPU/mem overlays and edge animation
-- WASM agent simulation layer (wasmi 0.31): SimEngine, SimCapStore, SimEventBus (`e74d6c1`)
-- run-agent CLI: load and execute signed WASM agents on the host
-- WASM agent signature verification (agentos.signature section, SHA-512)
-- Multi-agent orchestration via SimOrchestrator with channel routing
-- Console tab: default landing panel; Getting Started banner when offline
-- Agents panel: Spawn Agent modal with name + swap-slot selection
-- Topology: per-node title tooltips + status dot legend (`6680b7a`, `3e475f8`)
-- Sidebar nav: text labels always visible
-- Images panel: Import Image button + Download Buildroot shortcut
-- Profiler: CPU threshold legend (0-60% normal, 60-90% hot, 90%+ critical) (`63dc89e`)
-- Slot picker: grouped by category + View in Topology link
-- trace_recorder PD: full 512-entry circular ring with START/STOP/QUERY/DUMP (`81d2c36`)
-- Runtime capability policy loading from binary blob (cap_policy.bin)
-- Per-agent fault restart policy (max_restarts, escalation threshold) (`755ff96`)
-- tools/gen-channels: auto-generate typed channel enums from agentos.system
-- tools/gen-policy: compile policy.txt to binary cap_policy.bin
-- GitHub Actions CI: cargo test, trunk build, WASM examples, QEMU boot test (`4732120`)
-- WASM examples: health-monitor and log-aggregator agents
-- docs/ui-audit.md: expert UX evaluation against virt-manager/VMware Fusion (`bfda2ec`)
-- Fault injection framework + CI adversarial test suite (`8696592`)
-- Seeded ring buffer library with typed shared-memory channels (`814fdb9`)
-- seL4 secure inter-VM GPU zero-copy shared memory channel (`8434b1a`)
-- Capability attestation: cap_broker_attest() with SHA-256 signed snapshot (`cacf418`, `927564a`)
-- CAmkES-style SDF generator: gen_sdf.py + topology.yaml (`e9df40b`)
-- topology.yaml validation gate in GitHub Actions CI (`498b332`)
-- seL4 time-partitioning scheduler PD: fixed CPU budget per agent class (`8f581a0`)
-- OP_PUBLISH_BATCH: coalesce up to 16 MsgBus events per seL4_Call (`7d91ef4`, `f5f48dd`)
-- console_mux PD: session multiplexer ('tmux for agentOS') (`844d37c`)
-- VibeEngine hot-reload: zero-downtime WASM slot update (OP_VIBE_HOTRELOAD 0x47) (`6d33f96`)
-- VM multiplexer: create/destroy/switch 4 FreeBSD instances under seL4 (`5cf9a1d`)
-- mem_profiler PD: per-slot WASM heap tracking, leak detection, quota alerts (`3298a02`)
-- OOM killer PD: score-based WASM slot eviction under memory pressure (`6056ffa`)
-- snapshot_sched PD: periodic WASM slot checkpointing to AgentFS (`45aa96b`, `f93913d`)
-- cap_policy hot-reload: OP_CAP_POLICY_RELOAD updates grants without reboot (`fc75085`, `f5f3392`)
-- core_affinity PD: CPU affinity scheduling for WASM slots (`d9faecd`)
-- agentctl ncurses TUI for pre-boot menu and console session manager (`1b2918c`)
-- x86_64 Linux VMM stub and system manifest (`31226a7`)
-- FreeBSD VMM: boot FreeBSD AArch64 as VM guest under seL4 (`a7aaf13`)
-- power_mgr PD: DVFS thermal management for sparky GB10 (`1011c1e`)
-- dev_shell PD: interactive seL4 debug REPL for QEMU (`4b15330`, `3d4f2b7`)
-- Raft consensus for distributed agent mesh (`2adbe15`)
-- GPU scheduler PD for CUDA workload routing on Sparky (`0fe9d12`, `b1a5d3e`)
-- CUDA PTX compute offload via WASM custom sections (agentos.cuda) (`bfe77c0`)
-- Distributed agent mesh PD + SquirrelBus bridge (`e3518e5`)
-- WASM module registry cache + boot replay (`e683af6`)
-- Linux VMM integration via libvmm (AArch64) (`895f2fe`)
-- ARM64 (AArch64) port: builds and boots on QEMU virt (`90d0b5d`)
-- VibeEngine PD: WASM hot-swap pipeline (`fc4329f`)
-- quota_pd: per-agent CPU/memory quota enforcement with seL4 cap revocation (`18f8799`, `6a3ee67`)
-- debug_bridge_pd: seL4 debug channel for live WASM slot debugging (`93e59dc`)
-- IPC perf counters PD + wasm3 heap_stats hook (`de1fdb4`)
-- Multi-arch build system: riscv64, aarch64, x86_64 (`08d84fb`)
-- Profiler tab: live WASM slot flame graph on dashboard (`63dc89e`)
-- agentOS Python SDK (agentos_sdk) (`a1a7b9c`)
-- Release automation via `make release` (cargo xtask) (`26d72ac`)
-- Full-duplex console, trace_recorder PD, FreeBSD lazy loader, API tests (`7ef82d3`)
-- Idempotent guest OS fetch wired into make + GUI download buttons (`b23597d`)
-- xterm.js terminal console dashboard (`b472afb`)
-- Rust migration: all userspace and build tooling from Python/JS to Rust (`bd589c4`)
-- agentOS v0.1.0-alpha: first boot (`8650b14`)
+- Give each physical device frame and IRQ one agentOS driver PD owner; Linux
+  and FreeBSD guests receive no host MMIO or interrupt capabilities.
+- Translate and bounds-check guest physical addresses for VirtIO net, block,
+  console, sound, and diagnostic paths instead of identity-mapping guest RAM
+  into a VMM.
+- Isolate Linux and FreeBSD guest VSpaces and reserve their RAM before loading
+  ordinary PD images.
+- Preserve queue ownership under backpressure: receive traffic drains across
+  descriptor cycles, and rejected console frames are retried without silently
+  diverting bytes to an inactive early console.
+- Require distinct, ephemeral, key-only SSH identities for automated guest
+  access. The experimental desktop protocol is designed to remain confined to
+  an authenticated SSH tunnel.
+- Enforce the repository-wide C, Rust, and Assembly language policy and remove
+  the repository-owned interactive UI path.
 
-### Build
-- Correct modern virtio-net host headers so guest Ethernet and SSH traffic
-  remain byte-aligned
-- Enforce the repository-wide C/Rust/Assembly and no-UI policy in host gates
-- Kernel builds cleanly for riscv64 and aarch64 targets (`806be81`, `f319000`)
-- Fixed: duplicate opcode OP_CAP_POLICY_RELOAD in agentos.h (`806be81`)
-- Fixed: SWAP_SLOT_BASE_CH was 8, corrected to 30
-- Fixed: off-by-one in log.c hex buffer (buf[18]→buf[19]) (`fab13bb`)
-- Fixed: NULL and integer limit macro redefinition guards
-- Fixed: QEMU TCG flags on Apple Silicon (aarch64 cortex-a53, no HVF) (`fab13bb`)
-- Fixed: WASM bounds checking and priority inversion (`33c1531`, `08e512c`)
-- Fixed: ring buffer overflow signal (`33c1531`)
-- Fixed: five major OS security findings addressed in two passes (`c8dd3ea`, `0c5dbdd`)
-- Fixed: critical OS security findings from design review (`ec868f8`, `8e98874`)
-- channels_generated.h auto-generated from agentos.system XML
-- Fixed: console_log migration build breaks — missing includes, redef, invalid channel id (`1f1fb41`)
-- Fixed: controller PD crash and serial output wiring to console panes (`dc2fbda`)
-- Fixed: bridge-as-server socket so QEMU connects as client (`94c6af7`)
-- Fixed: duplicate res.writeHead() in /api/vm/images handler (`72ec0ba`)
-- Fixed: cortex-a72 CPU for TCG (host CPU requires KVM/HVF) (`d1b2d6e`)
-- Fixed: m3_bare_metal.c missing from PD_MONITOR_SRCS on ARM64 (`9f7224a`)
-- Fixed: Homebrew split llvm/lld formulae on macOS (`9133e82`)
-- Fixed: Microkit SDK download + Homebrew LLVM PATH for macOS (`c8f243e`)
-- Fixed: stale microkit-sdk symlink removed (`1415452`)
-- Fixed: git submodule auto-initialisation when missing (`08dca11`)
-- Fixed: console renamed to agentOS console with build error fixes (`c2da13e`)
-- Fixed: controller links, system file validity (`9fd898f`)
-- scripts/boot-test.sh: reusable QEMU serial banner verification with configurable timeout
-- .github/workflows/ci.yml: dedicated boot-test job (riscv64 + QEMU serial banner check)
+### Added
+
+- VMM-emulated VirtIO net, block, and console devices backed by agentOS-owned
+  driver and virtualizer queues. QEMU VirtIO transports are host-hardware
+  stand-ins only and are not advertised to guests.
+- Guest-visible packet, block-I/O, and bidirectional console proofs for the
+  Buildroot and Ubuntu AArch64 paths.
+- Ubuntu 26.04 and FreeBSD 15.0 AArch64 guest lifecycle paths with isolated
+  memory, separate network identities, independent block media, and a staged
+  concurrent authenticated-SSH acceptance gate.
+- An experimental Ubuntu software-desktop gate that starts the graphical
+  workload in the guest and can record a bounded RFB 3.8 raw-frame checksum
+  through SSH. It is not part of the v0.2 OS release claim.
+- A native agent sDDF network client alongside the VMM clients, demonstrating
+  that native components and compatibility guests share the same virtualizer
+  boundary.
+- An evidence-bound Rust release workflow with read-only planning, metadata
+  preparation, exact-revision gates, authorized publication, annotated tags,
+  receipts, and remote verification.
+- A repository-owned Rust PDF renderer for the release systems/security deck,
+  with source- and fact-ledger hashes plus structural QA evidence.
+- Executable GitHub Actions coverage for host contracts, both root-task
+  architectures, Buildroot guest I/O, and the Ubuntu agentOS-VirtIO path.
+
+### Changed
+
+- Make is the canonical setup, build, test, demo, and release interface.
+- Host setup fails closed when required guest-staging or target tools are
+  unavailable and uses one configurable external Microkit SDK.
+- Guest lifecycle and console handling share common flavor-neutral validation,
+  while Linux and FreeBSD retain separate VMM implementations for now.
+- Release claims are explicitly tiered: host tests, target tests, guest-visible
+  behavior, concurrent authenticated access, and desktop evidence are distinct
+  gates.
+
+### Known limitations
+
+- The agentOS target and emulated-device paths are qualified on QEMU AArch64.
+  The x86_64 target proves the reduced agentOS root-task topology only; it does
+  not yet execute an x86 guest.
+- Ubuntu live-media boot is not release-qualified: systemd 259.5 can stall
+  before login under QEMU TCG. Consequently, concurrent Ubuntu/FreeBSD SSH and
+  the software-desktop path remain experimental in v0.2.
+- Canonical VirtIO GPU and input devices are future work.
+- FreeBSD acceptance uses read-only live media and an ephemeral SSH setup.
+- The release is development evidence, not a completed production security,
+  availability, side-channel, or bare-metal qualification.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/agentOS/agentos"

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@
 
 .DEFAULT_GOAL := help
 
-.PHONY: all setup sdk demo demo-check demo-smoke demo-test demo-desktop demo-desktop-test demo-clean install deps deps-tools submodules channels format policy-check run run-fast run-dual-ssh test test-guest-login test-guest-net test-guest-blk test-guest-console test-ubuntu-virtio test-ubuntu-live sel4-test-image run-tests test-snapshot-sched test-power-mgr test-proc-server test-vibeos-contract test-integration test-host gate gate-aarch64 gate-x86_64 e2e e2e-guest e2e-contract e2e-dual-os e2e-ubuntu-amd64 e2e-ubuntu-arm64 e2e-nixos e2e-freebsd15 e2e-all bootstrap-guest clean clean-all clean-images help release release-minor release-major release-prepare release-check release-publish release-verify fetch-guest build-tools
+.PHONY: all setup sdk demo demo-check demo-smoke demo-test demo-desktop demo-desktop-test demo-clean install deps deps-tools submodules channels format policy-check run run-fast run-dual-ssh test test-guest-login test-guest-net test-guest-blk test-guest-console test-ubuntu-virtio test-ubuntu-live sel4-test-image run-tests test-snapshot-sched test-power-mgr test-proc-server test-vibeos-contract test-integration test-host gate gate-aarch64 gate-x86_64 e2e e2e-guest e2e-contract e2e-dual-os e2e-ubuntu-amd64 e2e-ubuntu-arm64 e2e-nixos e2e-freebsd15 e2e-all bootstrap-guest clean clean-all clean-images help release release-minor release-major release-prepare release-check release-publish release-verify presentation-render fetch-guest build-tools
 
 # ─── Read config.yaml (if present) ───────────────────────────────────────────
 CONFIG_TARGET := $(shell grep '^target_arch:' config.yaml 2>/dev/null | sed 's/target_arch:[[:space:]]*//' | tr -d '[:space:]')
@@ -1087,6 +1087,13 @@ release-verify:
 		(echo "Usage: make release-verify RELEASE_VERSION=X.Y.Z" && exit 1)
 	@cargo xtask release verify --version $(RELEASE_VERSION)
 
+PRESENTATION_EDITION ?= dev
+PRESENTATION_PDF ?= build/presentations/agentos-systems-security-v$(PRESENTATION_EDITION).pdf
+
+presentation-render:
+	@cargo xtask render-deck --edition $(PRESENTATION_EDITION) --output $(PRESENTATION_PDF) \
+		$(if $(filter 1,$(PRESENTATION_VISUAL_REVIEW)),--visual-review,)
+
 # =============================================================================
 # help
 # =============================================================================
@@ -1172,6 +1179,7 @@ help:
 	@echo "  make policy-check     Enforce language/UI policy and xtask formatting"
 	@echo "  make release          Print a read-only patch-release plan"
 	@echo "  make release-prepare/check/publish/verify  Advance explicit release states"
+	@echo "  make presentation-render PRESENTATION_EDITION=X.Y.Z  Render and validate the release PDF"
 	@echo ""
 	@echo "Quick start:"
 	@echo "  make setup"

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ aos_service_swap(proposal_id);
 
 ### Prerequisites
 
-- macOS with Homebrew, or Ubuntu 22.04+
+- macOS with Homebrew, or Ubuntu 24.04
 - 8GB RAM, 20GB disk
 - QEMU for simulation (no hardware needed to start)
 - Rust, LLVM/Clang, LLD, and the seL4 Microkit 2.1.0 SDK
@@ -469,6 +469,8 @@ See [`docs/freebsd-vm-guest.md`](docs/freebsd-vm-guest.md) for the full design d
   protocol and gate matrix.
 - [`docs/presentations/agentos-systems-security/deck.md`](docs/presentations/agentos-systems-security/deck.md)
   is the editable, claim-labeled narrative for OS and security experts.
+- `make presentation-render PRESENTATION_EDITION=X.Y.Z` renders that source as
+  a PDF plus checksum-bearing QA receipt under `build/presentations/`.
 
 ---
 

--- a/docs/presentations/agentos-systems-security/FACTS.md
+++ b/docs/presentations/agentos-systems-security/FACTS.md
@@ -15,13 +15,14 @@ edition. “Planned” and “under qualification” are not synonyms for shippe
 | Guests receive canonical virtio-gpu and virtio-input devices | Planned for 0.3 | Linux DRM/input enumeration and captured frame | No host display MMIO or IRQ passthrough is permitted. |
 | x86_64 guest operating systems run under agentOS | Planned for 0.4 | VMX/EPT target evidence and Linux userspace execution | Current x86 work proves a reduced root-task topology, not guest support. |
 | Omarchy is a supported agentOS guest | Conditional 0.6 direction | Official reproducible artifact, encrypted persistent install, SSH, compositor, input, frame, update, and recovery gates | Do not claim support while official architecture/artifact requirements are unmet. |
-| Releases bind claims and gates to one exact revision | Planned for 0.2 | Checked release receipt and remote verification | Current shell and Rust release paths overlap and are not the final authority. |
+| Releases bind claims and gates to one exact revision | Current implementation | `xtask release`, `docs/RELEASES.md`, host tests | This edition's checked receipt and remote verification are produced during publication, after its PDF is frozen. |
 
 ## Evidence still required for the first edition
 
 - A retained successful `make demo-test` transcript from the release revision.
 - Desktop process, protocol-handshake, and non-empty-frame evidence.
-- A checked release-plan receipt produced by the replacement Rust workflow.
+- This edition's checked release receipt and remote verification, produced
+  during publication after its PDF is frozen.
 - One real malformed-request or guest-fault recovery trace.
 - A current capability path diagram generated from the shipping system
   description rather than redrawn from memory.

--- a/docs/presentations/agentos-systems-security/README.md
+++ b/docs/presentations/agentos-systems-security/README.md
@@ -7,11 +7,21 @@ virtualization, and security audiences.
 - `FACTS.md` is the claim ledger that must be refreshed from current source and
   runtime evidence before a release edition is rendered.
 
-The portable baseline is Markdown. A future renderer must be implemented in C
-or Rust, write generated files beneath `build/`, preserve editable text and
-speaker notes, and have a top-level Make entry point. No JavaScript, Python,
-HTML, browser runtime, private Literate AI implementation, or mandatory cloud
-connector may be introduced.
+The portable baseline is Markdown. The repository-owned Rust renderer writes a
+PDF and a checksum-bearing QA receipt beneath `build/`, preserves editable text
+and speaker notes in the source, and excludes those notes from audience pages.
+Render a release edition with:
+
+```text
+make presentation-render PRESENTATION_EDITION=0.2.0
+```
+
+The first render leaves `visual_review=required` in the adjacent QA receipt.
+After reviewing the complete contact sheet and representative dense pages,
+rerun with `PRESENTATION_VISUAL_REVIEW=1` to record that manual check.
+
+No JavaScript, Python, HTML, browser runtime, private Literate AI
+implementation, or mandatory cloud connector is involved.
 
 ## Edition policy
 

--- a/docs/presentations/agentos-systems-security/deck.md
+++ b/docs/presentations/agentos-systems-security/deck.md
@@ -6,6 +6,10 @@ security reviewers.
 Central claim: a guest operating system should be a replaceable,
 least-authority component of the machine—not the machine's trusted center.
 
+For operating-systems implementers, virtualization engineers, and security
+reviewers: make each guest OS a replaceable, least-authority component rather
+than the machine's trusted center.
+
 > Speaker notes: This is a technical argument, not a product launch. Separate
 > source-backed current behavior from gates still under qualification and from
 > roadmap architecture on every page.
@@ -279,7 +283,7 @@ Guest support still requires:
 
 ## 13. Releases bind claims to one revision
 
-**0.2 release-engineering milestone**
+**Current release mechanism**
 
 ```text
 plan (read-only)
@@ -292,9 +296,9 @@ plan (read-only)
 The plan names the claims and their gates. Any change to code, policy, gate
 selection, or artifacts invalidates the checked receipt.
 
-> Speaker notes: Today the repository has overlapping shell and Rust release
-> mutation paths. `docs/RELEASES.md` records the replacement protocol; do not
-> present it as implemented until its MAC task closes.
+> Speaker notes: `xtask release` is the sole mutation authority and the Make
+> targets are thin entry points. The checked receipt and remote verification
+> for this edition are publication evidence created after the deck is frozen.
 
 ---
 

--- a/libs/rust-pd/Cargo.toml
+++ b/libs/rust-pd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-pd"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 description = "Rust Protection Domain runtime for seL4 Microkit on agentOS"
 license = "Apache-2.0"

--- a/tools/attest-verify/Cargo.toml
+++ b/tools/attest-verify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attest-verify"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/tools/gen-abi/Cargo.toml
+++ b/tools/gen-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-abi"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/tools/gen-ringbuf/Cargo.toml
+++ b/tools/gen-ringbuf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-ringbuf"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/tools/gen-sdf/Cargo.toml
+++ b/tools/gen-sdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-sdf"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/tools/make-swap-image/Cargo.toml
+++ b/tools/make-swap-image/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "make-swap-image"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/tools/run-agent/Cargo.toml
+++ b/tools/run-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "run-agent"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 description = "agentOS CLI — load and run a signed .wasm agent on the host using the sim layer"
 license = "Apache-2.0"

--- a/tools/sign-wasm/Cargo.toml
+++ b/tools/sign-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sign-wasm"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/tools/trace-replay/Cargo.toml
+++ b/tools/trace-replay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trace-replay"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/userspace/agents/init-agent/Cargo.toml
+++ b/userspace/agents/init-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-init-agent"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [features]

--- a/userspace/sdk/Cargo.toml
+++ b/userspace/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-sdk"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 description = "agentOS SDK - core abstractions for agent-native operating system"
 license = "Apache-2.0"

--- a/userspace/servers/capability-broker/Cargo.toml
+++ b/userspace/servers/capability-broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-capability-broker"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 description = "Simulation model of the CapBroker PD — NOT deployed on seL4"
 

--- a/userspace/servers/event-bus/Cargo.toml
+++ b/userspace/servers/event-bus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-event-bus"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 description = "Simulation model of the EventBus PD — NOT deployed on seL4"
 

--- a/userspace/servers/http-gateway/Cargo.toml
+++ b/userspace/servers/http-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-http-gateway"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 description = "HTTP Gateway — hyper-based HTTP/1.1 server that dispatches requests to agentOS apps via http_svc"
 

--- a/userspace/servers/model-proxy/Cargo.toml
+++ b/userspace/servers/model-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-model-proxy"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 description = "Model Proxy - capability-gated LLM inference service for agentOS"
 

--- a/userspace/servers/tool-registry/Cargo.toml
+++ b/userspace/servers/tool-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-tool-registry"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 description = "Tool Registry - capability-gated tool registration and dispatch for agentOS"
 

--- a/userspace/servers/vibe-engine/Cargo.toml
+++ b/userspace/servers/vibe-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-vibe-engine"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 description = "Vibe Engine - service hot-swap protocol for agentOS vibe-coding"
 

--- a/userspace/sim/Cargo.toml
+++ b/userspace/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-sim"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 description = "agentOS WASM agent simulator — runs signed .wasm agents on the host with mock seL4 Microkit IPC"
 license = "Apache-2.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/xtask/src/cmd_render_deck.rs
+++ b/xtask/src/cmd_render_deck.rs
@@ -1,0 +1,475 @@
+use crate::RenderDeckArgs;
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::process::Command;
+
+const PAGE_WIDTH: f32 = 960.0;
+const PAGE_HEIGHT: f32 = 540.0;
+const LEFT: f32 = 72.0;
+const BOTTOM_LIMIT: f32 = 48.0;
+
+#[derive(Debug)]
+struct Slide {
+    title: String,
+    lines: Vec<Line>,
+}
+
+#[derive(Debug)]
+struct Line {
+    text: String,
+    style: Style,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Style {
+    Body,
+    Bullet,
+    Subhead,
+    Code,
+    Blank,
+}
+
+pub fn run(args: &RenderDeckArgs) -> Result<()> {
+    let source = fs::read_to_string(&args.input)
+        .with_context(|| format!("failed to read {}", args.input.display()))?;
+    let facts = fs::read_to_string(&args.facts)
+        .with_context(|| format!("failed to read {}", args.facts.display()))?;
+    let slides = parse_deck(&source)?;
+    let revision = git_revision().unwrap_or_else(|| "working-tree".to_string());
+    let pdf = render_pdf(&slides, &args.edition, &revision)?;
+
+    if let Some(parent) = args.output.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&args.output, &pdf)
+        .with_context(|| format!("failed to write {}", args.output.display()))?;
+
+    let qa_path = args.output.with_extension("qa.txt");
+    let source_hash = format!("{:x}", Sha256::digest(source.as_bytes()));
+    let facts_hash = format!("{:x}", Sha256::digest(facts.as_bytes()));
+    let pdf_hash = format!("{:x}", Sha256::digest(&pdf));
+    let qa = format!(
+        "schema=agentos.presentation.qa.v1\n\
+edition={}\n\
+source_revision={}\n\
+source={}\n\
+source_sha256={}\n\
+facts={}\n\
+facts_sha256={}\n\
+pdf={}\n\
+pdf_sha256={}\n\
+pages={}\n\
+renderer=xtask-raw-pdf-v1\n\
+fonts=PDF-Base-14 Helvetica,Helvetica-Bold\n\
+page_size_points=960x540\n\
+structural_validation=pass\n\
+overflow_validation=pass\n\
+speaker_notes_excluded=pass\n\
+visual_review={}\n",
+        args.edition,
+        revision,
+        args.input.display(),
+        source_hash,
+        args.facts.display(),
+        facts_hash,
+        args.output.display(),
+        pdf_hash,
+        slides.len(),
+        if args.visual_review {
+            "pass"
+        } else {
+            "required"
+        },
+    );
+    fs::write(&qa_path, qa)?;
+    println!(
+        "[xtask:deck] rendered {} pages to {} (QA: {})",
+        slides.len(),
+        args.output.display(),
+        qa_path.display()
+    );
+    Ok(())
+}
+
+fn parse_deck(source: &str) -> Result<Vec<Slide>> {
+    let mut slides = Vec::new();
+    for section in source.split("\n---\n") {
+        let mut title = None;
+        let mut lines = Vec::new();
+        let mut in_code = false;
+        let mut in_notes = false;
+        let mut in_metadata = false;
+
+        for raw in section.lines() {
+            let trimmed = raw.trim();
+            if trimmed.starts_with("> Speaker notes:") {
+                in_notes = true;
+                continue;
+            }
+            if in_notes {
+                continue;
+            }
+            if trimmed.starts_with("Audience:") || trimmed.starts_with("Central claim:") {
+                in_metadata = true;
+                continue;
+            }
+            if title.is_none() && (trimmed.starts_with("# ") || trimmed.starts_with("## ")) {
+                let heading = trimmed.trim_start_matches('#').trim();
+                title = Some(strip_slide_number(heading));
+                continue;
+            }
+            if trimmed == "```text" || trimmed == "```" {
+                in_code = !in_code;
+                continue;
+            }
+            if trimmed.is_empty() {
+                if in_metadata {
+                    in_metadata = false;
+                    continue;
+                }
+                if !matches!(
+                    lines.last(),
+                    Some(Line {
+                        style: Style::Blank,
+                        ..
+                    })
+                ) {
+                    lines.push(Line {
+                        text: String::new(),
+                        style: Style::Blank,
+                    });
+                }
+                continue;
+            }
+            if in_metadata {
+                continue;
+            }
+
+            let (style, text) = if in_code {
+                (Style::Code, trimmed.to_string())
+            } else if trimmed.starts_with("**") && trimmed.ends_with("**") {
+                (Style::Subhead, trimmed.trim_matches('*').to_string())
+            } else if let Some(text) = trimmed.strip_prefix("- ") {
+                (Style::Bullet, text.to_string())
+            } else {
+                (Style::Body, trimmed.to_string())
+            };
+            lines.push(Line { text, style });
+        }
+
+        let title = title.context("every slide section must have a heading")?;
+        while matches!(
+            lines.last(),
+            Some(Line {
+                style: Style::Blank,
+                ..
+            })
+        ) {
+            lines.pop();
+        }
+        slides.push(Slide { title, lines });
+    }
+    anyhow::ensure!(!slides.is_empty(), "deck contains no slides");
+    Ok(slides)
+}
+
+fn strip_slide_number(heading: &str) -> String {
+    if let Some((prefix, rest)) = heading.split_once(". ") {
+        if prefix.chars().all(|c| c.is_ascii_digit()) {
+            return rest.to_string();
+        }
+    }
+    heading.to_string()
+}
+
+fn render_pdf(slides: &[Slide], edition: &str, revision: &str) -> Result<Vec<u8>> {
+    let mut objects: Vec<Vec<u8>> = vec![Vec::new(); 4];
+    objects[0] = b"<< /Type /Catalog /Pages 2 0 R >>".to_vec();
+    objects[2] = b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_vec();
+    objects[3] = b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>".to_vec();
+
+    let mut page_ids = Vec::new();
+    for (index, slide) in slides.iter().enumerate() {
+        let content = render_slide(slide, index, slides.len(), edition, revision)?;
+        let content_id = objects.len() + 1;
+        objects.push(
+            format!(
+                "<< /Length {} >>\nstream\n{}\nendstream",
+                content.len(),
+                content
+            )
+            .into_bytes(),
+        );
+        let page_id = objects.len() + 1;
+        objects.push(
+            format!(
+                "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {PAGE_WIDTH} {PAGE_HEIGHT}] \
+                 /Resources << /Font << /F1 3 0 R /F2 4 0 R >> >> /Contents {content_id} 0 R >>"
+            )
+            .into_bytes(),
+        );
+        page_ids.push(page_id);
+    }
+    let kids = page_ids
+        .iter()
+        .map(|id| format!("{id} 0 R"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    objects[1] = format!("<< /Type /Pages /Count {} /Kids [{kids}] >>", slides.len()).into_bytes();
+    encode_pdf(&objects)
+}
+
+fn render_slide(
+    slide: &Slide,
+    index: usize,
+    total: usize,
+    edition: &str,
+    revision: &str,
+) -> Result<String> {
+    let cover = index == 0;
+    let mut commands = String::from("0.035 0.055 0.09 rg 0 0 960 540 re f\n");
+    commands.push_str("0.20 0.78 0.70 rg 0 512 960 8 re f\n");
+    let title_size = if cover { 50.0 } else { 36.0 };
+    let title_y = if cover { 360.0 } else { 452.0 };
+    let title_width = if cover { 30 } else { 48 };
+    let title_lines = wrap_words(&slide.title, title_width);
+    let mut y = title_y;
+    for line in title_lines {
+        pdf_text(
+            &mut commands,
+            "F2",
+            title_size,
+            LEFT,
+            y,
+            &line,
+            (0.95, 0.97, 1.0),
+        );
+        y -= title_size * 1.12;
+    }
+    y -= if cover { 24.0 } else { 14.0 };
+
+    for line in &slide.lines {
+        match line.style {
+            Style::Blank => y -= 11.0,
+            Style::Subhead => {
+                y -= 4.0;
+                for text in wrap_words(&line.text, 72) {
+                    pdf_text(
+                        &mut commands,
+                        "F2",
+                        22.0,
+                        LEFT,
+                        y,
+                        &text,
+                        (0.20, 0.78, 0.70),
+                    );
+                    y -= 29.0;
+                }
+            }
+            Style::Bullet => {
+                for (part, text) in wrap_words(&line.text, 82).into_iter().enumerate() {
+                    let prefix = if part == 0 { "- " } else { "  " };
+                    pdf_text(
+                        &mut commands,
+                        "F1",
+                        17.0,
+                        LEFT + 10.0,
+                        y,
+                        &format!("{prefix}{text}"),
+                        (0.90, 0.92, 0.95),
+                    );
+                    y -= 22.0;
+                }
+            }
+            Style::Code => {
+                pdf_text(
+                    &mut commands,
+                    "F1",
+                    16.0,
+                    LEFT + 18.0,
+                    y,
+                    &line.text,
+                    (0.72, 0.88, 0.84),
+                );
+                y -= 20.0;
+            }
+            Style::Body => {
+                for text in wrap_words(&line.text, 88) {
+                    pdf_text(
+                        &mut commands,
+                        "F1",
+                        17.0,
+                        LEFT,
+                        y,
+                        &text,
+                        (0.90, 0.92, 0.95),
+                    );
+                    y -= 22.0;
+                }
+            }
+        }
+    }
+    anyhow::ensure!(
+        y >= BOTTOM_LIMIT,
+        "slide {} overflows the page: {}",
+        index + 1,
+        slide.title
+    );
+
+    let short_revision = revision.get(..revision.len().min(12)).unwrap_or(revision);
+    pdf_text(
+        &mut commands,
+        "F1",
+        10.0,
+        LEFT,
+        24.0,
+        &format!("agentOS {edition} | {short_revision}"),
+        (0.55, 0.62, 0.70),
+    );
+    pdf_text(
+        &mut commands,
+        "F1",
+        10.0,
+        850.0,
+        24.0,
+        &format!("{}/{}", index + 1, total),
+        (0.55, 0.62, 0.70),
+    );
+    Ok(commands)
+}
+
+fn pdf_text(
+    out: &mut String,
+    font: &str,
+    size: f32,
+    x: f32,
+    y: f32,
+    text: &str,
+    colour: (f32, f32, f32),
+) {
+    let text = ascii_text(text);
+    out.push_str(&format!(
+        "{} {} {} rg BT /{} {} Tf 1 0 0 1 {} {} Tm ({}) Tj ET\n",
+        colour.0,
+        colour.1,
+        colour.2,
+        font,
+        size,
+        x,
+        y,
+        escape_pdf(&text)
+    ));
+}
+
+fn wrap_words(text: &str, width: usize) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        if !current.is_empty() && current.len() + 1 + word.len() > width {
+            result.push(current);
+            current = String::new();
+        }
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(word);
+    }
+    if !current.is_empty() {
+        result.push(current);
+    }
+    if result.is_empty() {
+        result.push(String::new());
+    }
+    result
+}
+
+fn ascii_text(text: &str) -> String {
+    text.replace('→', "->")
+        .replace('—', "-")
+        .replace('–', "-")
+        .replace('“', "\"")
+        .replace('”', "\"")
+        .replace('’', "'")
+        .replace('…', "...")
+        .replace('×', "x")
+        .chars()
+        .map(|c| if c.is_ascii() { c } else { '?' })
+        .collect()
+}
+
+fn escape_pdf(text: &str) -> String {
+    text.replace('\\', "\\\\")
+        .replace('(', "\\(")
+        .replace(')', "\\)")
+}
+
+fn encode_pdf(objects: &[Vec<u8>]) -> Result<Vec<u8>> {
+    let mut pdf = b"%PDF-1.4\n%agentOS\n".to_vec();
+    let mut offsets = Vec::with_capacity(objects.len());
+    for (index, object) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{} 0 obj\n", index + 1).as_bytes());
+        pdf.extend_from_slice(object);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = pdf.len();
+    pdf.extend_from_slice(format!("xref\n0 {}\n", objects.len() + 1).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in offsets {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n",
+            objects.len() + 1
+        )
+        .as_bytes(),
+    );
+    anyhow::ensure!(pdf.starts_with(b"%PDF-1.4"), "invalid PDF header");
+    Ok(pdf)
+}
+
+fn git_revision() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notes_are_not_audience_content() {
+        let deck = "# Cover\n\nAudience: engineers and\nreviewers.\n\nCentral claim: internal\nmetadata.\n\nVisible.\n\n> Speaker notes: private\n> detail\n\n---\n\n## 1. Next\n\n- Item\n";
+        let slides = parse_deck(deck).unwrap();
+        assert_eq!(slides.len(), 2);
+        assert!(!slides[0]
+            .lines
+            .iter()
+            .any(|line| line.text.contains("private")));
+        assert!(!slides[0]
+            .lines
+            .iter()
+            .any(|line| line.text.contains("reviewers") || line.text.contains("metadata")));
+        assert!(slides[0].lines.iter().any(|line| line.text == "Visible."));
+        assert_eq!(slides[1].title, "Next");
+    }
+
+    #[test]
+    fn generated_pdf_has_one_page_per_slide() {
+        let deck = "# Cover\n\nVisible.\n\n---\n\n## 1. Next\n\n- Item\n";
+        let slides = parse_deck(deck).unwrap();
+        let pdf = render_pdf(&slides, "test", "0123456789abcdef").unwrap();
+        let text = String::from_utf8_lossy(&pdf);
+        assert!(text.starts_with("%PDF-1.4"));
+        assert_eq!(text.matches("/Type /Page ").count(), 2);
+        assert!(text.ends_with("%%EOF\n"));
+    }
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -14,6 +14,7 @@ pub mod cmd_gen_policy;
 pub mod cmd_host_test;
 pub mod cmd_policy_check;
 pub mod cmd_release;
+pub mod cmd_render_deck;
 pub mod cmd_run_tests;
 pub mod cmd_setup;
 pub mod cmd_test;
@@ -147,6 +148,31 @@ pub struct SetupArgs {
     /// Install missing tools automatically (macOS: brew, Linux: apt-get)
     #[arg(long)]
     pub install: bool,
+}
+
+#[derive(clap::Args)]
+pub struct RenderDeckArgs {
+    /// Editable Markdown slide source.
+    #[arg(
+        long,
+        default_value = "docs/presentations/agentos-systems-security/deck.md"
+    )]
+    pub input: std::path::PathBuf,
+    /// Factual claim ledger bound into the QA receipt.
+    #[arg(
+        long,
+        default_value = "docs/presentations/agentos-systems-security/FACTS.md"
+    )]
+    pub facts: std::path::PathBuf,
+    /// Generated PDF path. The QA receipt is written beside it.
+    #[arg(long)]
+    pub output: std::path::PathBuf,
+    /// Release or presentation edition recorded in the PDF footer and receipt.
+    #[arg(long)]
+    pub edition: String,
+    /// Record that the rendered contact sheet and representative full-size pages were reviewed.
+    #[arg(long)]
+    pub visual_review: bool,
 }
 
 #[derive(clap::Args)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,10 +2,11 @@ use clap::{Parser, Subcommand};
 use xtask::{
     cmd_ci_matrix, cmd_extract_freebsd_file, cmd_fault_inject, cmd_fetch_guest, cmd_gen_abi,
     cmd_gen_caps, cmd_gen_channels, cmd_gen_image, cmd_gen_pd_bundle, cmd_gen_policy,
-    cmd_host_test, cmd_policy_check, cmd_release, cmd_run_tests, cmd_setup, cmd_test, cmd_test_api,
-    CiMatrixArgs, ExtractFreebsdFileArgs, FaultInjectArgs, FetchGuestArgs, GenAbiArgs, GenCapsArgs,
-    GenChannelsArgs, GenImageArgs, GenPdBundleArgs, GenPolicyArgs, HostTestArgs, PolicyCheckArgs,
-    ReleaseArgs, RunTestsArgs, SetupArgs, TestApiArgs, TestArgs,
+    cmd_host_test, cmd_policy_check, cmd_release, cmd_render_deck, cmd_run_tests, cmd_setup,
+    cmd_test, cmd_test_api, CiMatrixArgs, ExtractFreebsdFileArgs, FaultInjectArgs, FetchGuestArgs,
+    GenAbiArgs, GenCapsArgs, GenChannelsArgs, GenImageArgs, GenPdBundleArgs, GenPolicyArgs,
+    HostTestArgs, PolicyCheckArgs, ReleaseArgs, RenderDeckArgs, RunTestsArgs, SetupArgs,
+    TestApiArgs, TestArgs,
 };
 
 #[derive(Parser)]
@@ -30,6 +31,9 @@ enum Cmd {
     FetchGuest(FetchGuestArgs),
     /// Automated release (version bump + git tag)
     Release(ReleaseArgs),
+    /// Render the release presentation and its deterministic QA receipt.
+    #[command(name = "render-deck")]
+    RenderDeck(RenderDeckArgs),
     /// Run the libvmm CI test matrix
     CiMatrix(CiMatrixArgs),
     /// Compile and run the API test suite only (TAP output)
@@ -71,6 +75,7 @@ fn main() -> anyhow::Result<()> {
         Cmd::Setup(a) => cmd_setup::run(&a),
         Cmd::FetchGuest(a) => cmd_fetch_guest::run(&a),
         Cmd::Release(a) => cmd_release::run(&a),
+        Cmd::RenderDeck(a) => cmd_render_deck::run(&a),
         Cmd::CiMatrix(a) => cmd_ci_matrix::run(&a),
         Cmd::TestApi(a) => cmd_test_api::run(&a),
         Cmd::RunTests(a) => cmd_run_tests::run(&a),


### PR DESCRIPTION
Prepares the v0.2.0 OS/service-layer release on top of PRs #110 and #111.

Included:
- workspace version 0.2.0 and evidence-bound release metadata
- original systems/security narrative plus a repository-owned Rust PDF renderer
- exact claim-tier release workflow and current limitations

Qualification:
- make test-host: pass
- make gate: pass (AArch64 and x86_64 reduced-root-task smoke)

Deliberately excluded from the v0.2 claim:
- Ubuntu live-media login, concurrent Ubuntu/FreeBSD SSH, and desktop workload qualification. Ubuntu systemd 259.5 stalls before login under QEMU TCG; these paths remain experimental and are deferred behind the pinned Debian guest/profile work.