### PR TITLE
platform: prepare v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-09-09
+
+### Added
+
+- Versioned TOML guest-personality profiles with bounded validation and a Rust
+  compiler that emits compact target runtime manifests.
+- Data-driven host recipes for artifact acquisition, provisioning, console
+  matching, and guest tests, including planned Debian, Arch, and Omarchy
+  profiles alongside the qualified Buildroot and Ubuntu paths.
+
+### Changed
+
+- Select guest boot, memory placement, devices, lifecycle, and tests from
+  capabilities in compiled manifests instead of distribution-specific target
+  branches.
+- Share one guest-neutral VMM implementation across Linux and FreeBSD
+  personalities while retaining generic boot-protocol executors.
+
+### Known limitations
+
+- Debian, Arch, Omarchy, and the Ubuntu live-media login path are roadmap
+  profiles and are not qualified by the v0.2.1 OS release claim.
+
 ## [0.2.0] - 2026-09-09
 
 ### Security

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/agentOS/agentos"

--- a/libs/rust-pd/Cargo.toml
+++ b/libs/rust-pd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-pd"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Rust Protection Domain runtime for seL4 Microkit on agentOS"
 license = "Apache-2.0"

--- a/tools/attest-verify/Cargo.toml
+++ b/tools/attest-verify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attest-verify"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/tools/gen-abi/Cargo.toml
+++ b/tools/gen-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-abi"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/tools/gen-ringbuf/Cargo.toml
+++ b/tools/gen-ringbuf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-ringbuf"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/tools/gen-sdf/Cargo.toml
+++ b/tools/gen-sdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-sdf"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/tools/make-swap-image/Cargo.toml
+++ b/tools/make-swap-image/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "make-swap-image"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/tools/run-agent/Cargo.toml
+++ b/tools/run-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "run-agent"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "agentOS CLI — load and run a signed .wasm agent on the host using the sim layer"
 license = "Apache-2.0"

--- a/tools/sign-wasm/Cargo.toml
+++ b/tools/sign-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sign-wasm"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/tools/trace-replay/Cargo.toml
+++ b/tools/trace-replay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trace-replay"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/userspace/agents/init-agent/Cargo.toml
+++ b/userspace/agents/init-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-init-agent"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [features]

--- a/userspace/sdk/Cargo.toml
+++ b/userspace/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-sdk"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "agentOS SDK - core abstractions for agent-native operating system"
 license = "Apache-2.0"

--- a/userspace/servers/capability-broker/Cargo.toml
+++ b/userspace/servers/capability-broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-capability-broker"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Simulation model of the CapBroker PD — NOT deployed on seL4"
 

--- a/userspace/servers/event-bus/Cargo.toml
+++ b/userspace/servers/event-bus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-event-bus"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Simulation model of the EventBus PD — NOT deployed on seL4"
 

--- a/userspace/servers/http-gateway/Cargo.toml
+++ b/userspace/servers/http-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-http-gateway"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "HTTP Gateway — hyper-based HTTP/1.1 server that dispatches requests to agentOS apps via http_svc"
 

--- a/userspace/servers/model-proxy/Cargo.toml
+++ b/userspace/servers/model-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-model-proxy"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Model Proxy - capability-gated LLM inference service for agentOS"
 

--- a/userspace/servers/tool-registry/Cargo.toml
+++ b/userspace/servers/tool-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-tool-registry"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Tool Registry - capability-gated tool registration and dispatch for agentOS"
 

--- a/userspace/servers/vibe-engine/Cargo.toml
+++ b/userspace/servers/vibe-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-vibe-engine"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Vibe Engine - service hot-swap protocol for agentOS vibe-coding"
 

--- a/userspace/sim/Cargo.toml
+++ b/userspace/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-sim"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "agentOS WASM agent simulator — runs signed .wasm agents on the host with mock seL4 Microkit IPC"
 license = "Apache-2.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Summary

- bump every workspace crate to 0.2.1
- document the data-driven guest personality runtime
- scope the release to the OS claim; roadmap guest profiles and Ubuntu live login remain unqualified

## Verification

- `make test-host`
- protected-main required CI before merge
- exact-revision `make release-check RELEASE_VERSION=0.2.1 RELEASE_CLAIM=os` after merge

Refs: task_57c1a8b0b1a1b5ead88065d2e003a204