### PR TITLE
platform: prepare v0.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-09-09
+
+### Changed
+
+- Advance the workspace release after reconciling the duplicate GitHub issue
+  backlog into the canonical MAC task ledger and confirming that no stale
+  branches or worktrees remain.
+
+### Notes
+
+- This is an administrative maintenance checkpoint. Target and runtime code
+  are unchanged from v0.2.1, and the release retains the same OS claim.
+
 ## [0.2.1] - 2026-09-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/agentOS/agentos"

--- a/libs/rust-pd/Cargo.toml
+++ b/libs/rust-pd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-pd"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Rust Protection Domain runtime for seL4 Microkit on agentOS"
 license = "Apache-2.0"

--- a/tools/attest-verify/Cargo.toml
+++ b/tools/attest-verify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attest-verify"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [[bin]]

--- a/tools/gen-abi/Cargo.toml
+++ b/tools/gen-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-abi"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [[bin]]

--- a/tools/gen-ringbuf/Cargo.toml
+++ b/tools/gen-ringbuf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-ringbuf"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [[bin]]

--- a/tools/gen-sdf/Cargo.toml
+++ b/tools/gen-sdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-sdf"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [[bin]]

--- a/tools/make-swap-image/Cargo.toml
+++ b/tools/make-swap-image/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "make-swap-image"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [[bin]]

--- a/tools/run-agent/Cargo.toml
+++ b/tools/run-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "run-agent"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "agentOS CLI — load and run a signed .wasm agent on the host using the sim layer"
 license = "Apache-2.0"

--- a/tools/sign-wasm/Cargo.toml
+++ b/tools/sign-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sign-wasm"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [[bin]]

--- a/tools/trace-replay/Cargo.toml
+++ b/tools/trace-replay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trace-replay"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [[bin]]

--- a/userspace/agents/init-agent/Cargo.toml
+++ b/userspace/agents/init-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-init-agent"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [features]

--- a/userspace/sdk/Cargo.toml
+++ b/userspace/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-sdk"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "agentOS SDK - core abstractions for agent-native operating system"
 license = "Apache-2.0"

--- a/userspace/servers/capability-broker/Cargo.toml
+++ b/userspace/servers/capability-broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-capability-broker"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Simulation model of the CapBroker PD — NOT deployed on seL4"
 

--- a/userspace/servers/event-bus/Cargo.toml
+++ b/userspace/servers/event-bus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-event-bus"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Simulation model of the EventBus PD — NOT deployed on seL4"
 

--- a/userspace/servers/http-gateway/Cargo.toml
+++ b/userspace/servers/http-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-http-gateway"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "HTTP Gateway — hyper-based HTTP/1.1 server that dispatches requests to agentOS apps via http_svc"
 

--- a/userspace/servers/model-proxy/Cargo.toml
+++ b/userspace/servers/model-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-model-proxy"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Model Proxy - capability-gated LLM inference service for agentOS"
 

--- a/userspace/servers/tool-registry/Cargo.toml
+++ b/userspace/servers/tool-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-tool-registry"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Tool Registry - capability-gated tool registration and dispatch for agentOS"
 

--- a/userspace/servers/vibe-engine/Cargo.toml
+++ b/userspace/servers/vibe-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-vibe-engine"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Vibe Engine - service hot-swap protocol for agentOS vibe-coding"
 

--- a/userspace/sim/Cargo.toml
+++ b/userspace/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-sim"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "agentOS WASM agent simulator — runs signed .wasm agents on the host with mock seL4 Microkit IPC"
 license = "Apache-2.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Summary

- advance all workspace crates to 0.2.2
- record GitHub-to-MAC issue-ledger reconciliation
- explicitly document that target/runtime code and the OS claim are unchanged from v0.2.1

## Verification

- `make test-host`
- protected-main required CI before merge
- exact-revision `make release-check RELEASE_VERSION=0.2.2 RELEASE_CLAIM=os` after merge

Refs: task_6172a8855eec467f7b8baa6cbdff2dda