### PR TITLE
docs: README rewrite, quick start, developer guide, docs index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   and publishes it in the client storage_info page, so writable media and
   `VIRTIO_BLK_F_FLUSH` (#117) reach the guest through the virtualizer.
 
+### Documentation
+
+- `README.md` rewritten for the post-audit platform (what is proven today vs.
+  target, the booted PD set, quick start, current tree, proof levels).
+- New `docs/QUICKSTART.md` (clone to boot, guest proofs, demo, logs,
+  troubleshooting), `docs/DEVELOPER_GUIDE.md` (boot flow, declaring a PD,
+  contracts, notifications, adding a virtualizer or driver PD using `net_virt`
+  as the template, guest profiles, testing policy), and `docs/README.md`
+  (index marking current vs. historical documents). `DESIGN.md` carries a
+  banner pointing at `docs/TCB.md` and the README as current truth.
+
 ### Known limitations
 
 - `serial_virt` is not yet a separate PD; console bytes still reach `cc_pd`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -5,6 +5,16 @@
 **Date:** 2026-03-28
 **Status:** DESIGN PHASE
 
+> **Current truth lives elsewhere.** This is the March 2026 vision document.
+> The implementation status table below predates the 2026-09 trust-baseline
+> audit and still names services (CapStore, MsgBus, VibeOS, usb-service,
+> trace_recorder, the WASM hot-swap path) that are museum code and not in the
+> booted image. For what agentOS is and what is proven today, read
+> [`docs/TCB.md`](docs/TCB.md) (binding), then [`README.md`](README.md),
+> [`docs/ROADMAP.md`](docs/ROADMAP.md), and
+> [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md). Where this file and
+> `docs/TCB.md` disagree, `docs/TCB.md` is correct.
+
 > **Read this first — design vs. proof.** This document describes the *intended*
 > architecture. Much of it is aspirational. The implementation status of each
 > subsystem is tracked by **proof level** in the table below; do not read prose

--- a/README.md
+++ b/README.md
@@ -1,504 +1,236 @@
 # agentOS
 
-**The world's first operating system designed for agents, not humans.**
+agentOS is a bootable, capability-secured I/O and isolation platform on the
+[seL4](https://sel4.systems/) microkernel. It owns devices in user mode and
+hosts Linux and FreeBSD as virtio guests. QEMU is the hardware emulator used
+for prototyping; the same driver PDs that own QEMU's virtio devices today are
+meant to own real devices on a board.
 
 [![License](https://img.shields.io/badge/license-BSD--2--Clause-blue.svg)](LICENSE)
 [![Kernel](https://img.shields.io/badge/kernel-seL4-green.svg)](https://sel4.systems)
-[![Status](https://img.shields.io/badge/status-alpha-orange.svg)]()
 
----
+## What it is
 
-## What is agentOS?
-
-agentOS is a bootable operating system built on the [seL4 microkernel](https://sel4.systems/) — the world's only formally verified, capability-secured microkernel. It's designed from the ground up for AI agents running autonomous workloads.
-
-Every other "agent OS" is a Python framework running on Linux. They borrow a human OS, bolt some agent abstractions on top, and call it done. **agentOS is different.**
-
-agentOS boots bare metal. The root task, the seL4/Microkit boot path, and Linux
-and FreeBSD guest boot are **boot-proven** under QEMU (see the status table
-below). The capability model — agents running in isolated address spaces with
-hardware-enforced boundaries so an agent cannot touch memory, a tool, a model, or
-a storage namespace it doesn't hold a capability for — is the design seL4
-provides; in this repository the higher-level agent services are still mostly
-host-tested scaffolding, not yet exercised on the booted target.
-
-A core design goal is that **agents can redesign their own environment**: the
-vibe-coding layer is intended to let agents generate new system services
-(filesystems, message buses, tool registries), have them validated, and hot-swap
-them in without rebooting. Today the hot-swap pipeline is **host-tested** — its
-read/probe paths are validated, but proposing and swapping a real WASM component
-requires a mapped staging region and has not been proven on target.
-
-## Why seL4?
-
-- **Formally verified** — mathematical proof that the implementation matches the spec
-- **Capability-based security** — fine-grained, unforgeable access control
-- **No heap in the kernel** — deterministic, no memory surprises
-- **World-class IPC** — ~100 cycle synchronous IPC on ARM
-- **Policy freedom** — kernel provides mechanisms; agents define policies
-
-## Architecture
-
-QEMU is a hardware emulator for prototyping. agentOS is the platform that
-runs on that hardware (and later on a real board): user-mode drivers,
-sDDF virtualizers, and a VMM that presents **emulated virtio** to Linux and
-FreeBSD. Native agents use the same virtualizers without a guest OS.
-
-See [`docs/TCB.md`](docs/TCB.md) for the trust boundary,
-[`docs/guest-profiles.md`](docs/guest-profiles.md) for the data-driven guest
-contract,
-[`PLAN.md`](PLAN.md) for active implementation sequencing, and
-[`docs/ROADMAP.md`](docs/ROADMAP.md) for release milestones including the
-desktop and x86 guest paths.
+- **seL4** is the only kernel-mode code (EL2 on AArch64). It is never modified.
+- The **root task** (`kernel/agentos-root-task/`) distributes untyped memory,
+  CSpaces, VSpaces, and initial capabilities to a fixed set of protection
+  domains (PDs), then parks. It enforces no policy after spawn.
+- **Driver PDs** own exactly one device class each: a device frame plus its
+  IRQ. Nothing else maps that frame.
+- **Virtualizer PDs** own no device. They are the only multiplexer for a
+  class, moving data between clients over sDDF-shaped shared-memory queues
+  with seL4 notifications, and speaking the driver's contract on the clients'
+  behalf.
+- **VMM PDs** run a vCPU and vGIC and **emulate** virtio-mmio net, block, and
+  console devices for a guest, using `libvmm`. Guests run unmodified in-tree
+  virtio drivers. Guests never see host MMIO.
+- **Native agents** are clients of the virtualizers, the same as a VMM
+  backend. They are not in the trusted computing base.
 
 ```
  Hardware / QEMU
-      │
-      ▼
+      |
  seL4 (EL2)
-      ├── root task
-      ├── driver PDs + virtualizers (user mode)
-      └── VMM (emulated virtio-net/blk/console)
-            ├── Linux guest
-            └── FreeBSD guest
+   |-- root task
+   |-- driver PDs        serial_pd, net_pd, virtio_blk (+ block_pd)
+   |-- virtualizer PDs   net_virt, blk_virt         (console: still a library)
+   |-- guest_vmm_*       vCPU + vGIC + emulated virtio-net/blk/console
+   |     |-- Linux guest
+   |     '-- FreeBSD guest
+   '-- control           vm_manager, cc_pd, nameserver, log_drain, fault_handler
 ```
 
-## Core Concepts
+The binding description of the trust boundary, with a strict split between
+what boots today and the target shape, is [`docs/TCB.md`](docs/TCB.md). The
+project rules are [`CLAUDE.md`](CLAUDE.md) and [`AGENTS.md`](AGENTS.md).
 
-### Agent Identity
-Every agent has an Ed25519 keypair. Their badge on seL4 endpoints is derived from their identity. Message senders are verified at the kernel level — unforgeable.
+## Today vs. target
 
-### Capabilities
-Everything an agent can do requires a capability:
-- `ToolCap` — invoke a tool
-- `ModelCap` — query an LLM
-- `MemCap` — read/write memory regions
-- `MsgCap` — send/receive on a channel
-- `StoreCap` — access storage namespaces
-- `SpawnCap` — create new agents
-- `NetCap` — use network resources
+| Area | Today | Target |
+|------|-------|--------|
+| One owner per device frame and IRQ | Held (lint-enforced) | Same |
+| Network mux is a separate PD (`net_virt`) | Held | Same |
+| Block mux is a separate PD (`blk_virt`) | Held | Same |
+| Console mux is a separate PD (`serial_virt`) | Not yet: the console virtualizer is a library inside `guest_vmm`; bytes reach `cc_pd` by IPC | Separate `serial_virt` PD |
+| Virtio is the guest ABI; host QEMU virtio is never passed through | Held (`xtask qemu-test` rejects a host-backed proof that used the VMM-local loopback) | Same |
+| Guests are image + FDT, no agentOS-specific guest drivers | Held | Same |
+| Target hardware | QEMU `virt` AArch64 (full guest path); QEMU x86_64 boots the root task only | Bare metal; x86 guest execution is roadmap 0.4 |
+| `vibe_engine` in the image | Booted, not TCB: `cc_pd` relays dynamic-guest creation through it to `vm_manager` | Retired once `cc_pd` calls `vm_manager` directly |
 
-Capabilities are delegatable but never escalatable. An agent can grant a subset of what it holds.
+## Booted PD set
 
-### The Vibe-Coding Layer
+The default AArch64 image boots 13 PDs. The list is checked in two places that
+must agree: `kernel/agentos-root-task/src/system_desc_aarch64.c` (what the
+root task spawns) and `kernel/agentos-root-task/agentos.toml` (what is bundled
+into the image). A bundle entry with no descriptor row is never started; a
+descriptor row with no bundle entry fails at ELF load.
 
-This is the key design idea (proof level: **host-tested** — see status table).
-Every system service has a defined interface. The intended flow is that agents:
+| PD | Role | Source |
+|----|------|--------|
+| `nameserver` | Service name registry; spawned first | `kernel/agentos-root-task/src/nameserver.c` |
+| `log_drain` | Log ring drain | `kernel/agentos-root-task/src/log_drain.c` |
+| `serial_pd` | Owns the PL011 UART frame + IRQ | `services/serial-mux/serial_pd.c` |
+| `vibe_engine` | Dynamic-guest relay hop (not TCB) | `services/vibe-engine/vibe_engine.c` |
+| `virtio_blk` | Owns QEMU virtio-blk (bus.8) and the bounded DMA window | `kernel/agentos-root-task/src/virtio_blk.c` |
+| `block_pd` | Block service | `kernel/agentos-root-task/src/block_pd.c` |
+| `net_pd` | Owns QEMU virtio-net (bus.16) | `services/net-service/net_pd.c` |
+| `net_virt` | Network virtualizer; no device, no IRQ | `platform/net-virt/net_virt.c` |
+| `blk_virt` | Block virtualizer; no device, no IRQ | `platform/blk-virt/blk_virt.c` |
+| `guest_vmm_primary` | vCPU, vGIC, emulated virtio for the primary guest | `kernel/agentos-root-task/src/guest_vmm.c` |
+| `vm_manager` | Guest lifecycle control (create, bind, status) | `kernel/agentos-root-task/src/vm_manager.c` |
+| `cc_pd` | Owns QEMU virtio-serial (bus.2): the harness/`agentctl` console; prints `agentOS boot complete` | `kernel/agentos-root-task/src/cc_pd.c` |
+| `fault_handler` | Fault endpoint for the other PDs | `kernel/agentos-root-task/src/fault_handler.c` |
 
-1. Analyze the reference implementation
-2. Generate a better one (using ModelSvc)
-3. Propose it as a replacement via `aos_service_propose()`
-4. After validation, activate it via `aos_service_swap()`
+`guest_vmm_secondary`, `fault_inject`, `test_runner`, and `event_bus` are added
+only to the image variants that use them (dual-guest, fault-injection, and TAP
+test images). The other sources under `kernel/agentos-root-task/src/` and
+`services/` are still compiled so they keep building, but they are not in the
+image; `docs/TCB.md` lists them as museum code that must not be extended.
 
-The system is designed to evolve; the reference implementations are starting
-points, not permanent fixtures. As of today the hot-swap pipeline's read/probe
-paths are validated on the host, but a full propose+validate+swap of a real WASM
-component has not been proven on a booted target.
+## Quick start
 
-## System Services
+Full walkthrough: [`docs/QUICKSTART.md`](docs/QUICKSTART.md). Short form:
 
-These agent-facing services have IPC contracts in `contracts/` and host-side
-implementations/tests. Unless noted in the status table above, treat them as
-**host-tested** — their contracts and logic are validated on the host, not yet
-proven against a booted seL4 target.
-
-| Service | Description | Proof level |
-|---------|-------------|-------------|
-| `CapStore` | Capability database — tracks all cap derivations and grants | host-tested |
-| `MsgBus` | Inter-agent communication — channels, pub/sub, direct messaging, RPC | host-tested |
-| `MemFS` | Virtual filesystem — per-agent namespaces, capability-gated access | host-tested |
-| `ToolSvc` | Tool registry — agents register and invoke tools (MCP-compatible) | host-tested |
-| `ModelSvc` | Inference proxy — capability-gated LLM access, pluggable backends | host-tested |
-| `NetStack` | TCP/IP networking — lwIP-based, capability-gated per-endpoint | host-tested |
-| `BlobSvc` | Object storage — large binary objects, S3-compatible API | host-tested |
-| `LogSvc` | Audit logging — structured, queryable, every cap op recorded | host-tested |
-
-The system is implemented as seL4 Microkit Protection Domains with explicit IPC
-contracts. External tools consume the contracts; UI code lives in separate
-repositories such as `../agentos_gui`.
-
-## agentOS SDK (libagent)
-
-```c
-// Initialize agent
-aos_init(&config);
-
-// Send a message to another agent
-aos_msg_send(dest_id, message);
-
-// Publish to a channel
-aos_msg_publish(channel, message);
-
-// Call a tool
-aos_tool_call(tool_cap, "web_search", args, args_len, &result, &result_len);
-
-// Query a model
-aos_inference_t resp = aos_model_query(model_cap, prompt, &params);
-
-// Read/write storage
-aos_store_t f = aos_store_open(cap, "/path/to/file", AOS_STORE_RDWR);
-aos_store_write(f, data, len);
-
-// Propose a service replacement (vibe-coding)
-aos_service_propose("storage.v1", component_image, image_len, &proposal_id);
-aos_service_swap(proposal_id);
-```
-
-## Getting Started
-
-### Prerequisites
-
-- macOS with Homebrew, or Ubuntu 24.04
-- 8GB RAM, 20GB disk
-- QEMU for simulation (no hardware needed to start)
-- Rust, LLVM/Clang, LLD, and the seL4 Microkit 2.1.0 SDK
-- Vendor ISOs cache under `${AGENTOS_ISO_DIR:-$HOME/.cache/agentos/isos}`;
-  staged guest images live under `build/guest-images`
-- **FreeBSD hosts**: cross-compile from Linux/macOS (FreeBSD LLVM cross-compilation support is limited)
-
-### Dual-guest demo
+Host packages (the Makefile does not install these):
 
 ```bash
-make setup    # install dependencies, SDK, and validate the host
-make demo     # boot Ubuntu + FreeBSD, prove SSH, retain both for login
+# macOS
+brew install llvm lld qemu dtc libarchive zstd cmake ninja coreutils
+# Debian/Ubuntu
+sudo apt-get install -y clang lld llvm qemu-system-arm qemu-system-x86 \
+    device-tree-compiler libarchive-tools zstd cmake ninja-build curl
+# Rust (stable)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ```
 
-The demo runs one agentOS image with both guest VMMs, proves key-only SSH to
-Ubuntu on port 12222 and FreeBSD on port 12223, then prints the exact commands
-for opening both sessions. Press Enter in the original terminal to stop QEMU.
-See [`docs/demo.md`](docs/demo.md) for the complete walkthrough, expected
-runtime, proof boundary, and troubleshooting.
+Then:
 
 ```bash
-make demo-test   # same authenticated-SSH acceptance gate; exit afterward
-make demo-smoke  # fast host-only checks; no QEMU and not a boot proof
-make demo-clean  # remove demo runtime artifacts; preserve guest images
-make help        # lower-level build, run, and device-proof targets
+make setup                     # build xtask, download Microkit SDK 2.1.0, check tools
+make build TARGET_ARCH=aarch64 GUEST_OS=none
+make test  TARGET_ARCH=aarch64 GUEST_OS=none   # boot in QEMU, wait for "agentOS boot complete"
+make test-host                 # host-only suite + policy check + source lint
+make test-guest-net            # Buildroot: one frame through emulated virtio-net
+make test-guest-blk            # Buildroot: one request through emulated virtio-blk
+make test-guest-console        # Ubuntu initramfs: login over emulated virtio-console
+make gate                      # the OS-claim gate: all of the above plus x86_64 boot
 ```
 
-### Experimental desktop proof
+The Microkit SDK lands in `$HOME/.cache/agentos/microkit-sdk-2.1.0` unless
+`SEL4_SDK` points elsewhere. QEMU logs and control sockets go to `build/tmp/`;
+set `AGENTOS_TMP_DIR` to a short path when the checkout path is long (macOS
+caps Unix socket paths at 104 bytes). `make help` lists every target.
 
-`make demo-desktop` boots the Ubuntu ARM64 live guest, provisions a lightweight
-Openbox/TigerVNC session, verifies a raw RFB frame through key-authenticated
-SSH, and keeps the tunnel available to an external VNC viewer. It is not a
-framebuffer or virtio-gpu claim. Until the live gate is release-qualified,
-this remains an experimental path. See
-[`docs/desktop-demo.md`](docs/desktop-demo.md).
+The dual-guest demonstration (`make demo`, `make demo-test`) boots Ubuntu and
+FreeBSD concurrently and proves key-only SSH to both. See
+[`docs/demo.md`](docs/demo.md). It downloads two ISOs of about 4 GB each and
+runs for a long time under TCG.
 
-```bash
-make demo-desktop-test  # automated RFB protocol/frame evidence; exit afterward
-make demo-desktop       # retain the verified guest and SSH tunnel
-```
-
-### Lower-level build and run examples
-
-```bash
-make run GUEST_OS=ubuntu                         # foreground Ubuntu run
-make run GUEST_OS=freebsd                        # foreground FreeBSD run
-make test-guest-login                            # CC-PD console proof
-make build TARGET_ARCH=aarch64 GUEST_OS=ubuntu    # AArch64 + Ubuntu 26.04
-make build TARGET_ARCH=aarch64 GUEST_OS=freebsd   # AArch64 + FreeBSD 15.0
-make build TARGET_ARCH=aarch64 GUEST_OS=both      # Package both guest VMM PDs
-make build TARGET_ARCH=x86_64 GUEST_OS=none       # x86_64 root-task smoke image
-make fetch-guest GUEST_OS=ubuntu                  # stage Ubuntu assets only
-make fetch-guest GUEST_OS=freebsd                 # stage FreeBSD assets only
-make fetch-guest GUEST_OS=both                    # stage both guest OS assets
-```
-
-Guest images and temporary build artifacts stay under `build/`. Use
-`AGENTOS_IMAGES=/path/to/cache` only when intentionally overriding the default.
-The dual-guest demo automatically uses 3 GB of outer QEMU RAM. Both guests see
-the conventional `0x40000000` GPA window while their VMMs map disjoint host
-virtual-address windows. `make run-dual-ssh` remains as the lower-level alias
-used by `make demo`.
-
-### FreeBSD host
-
-```bash
-# Install build tools (LLVM, dtc, etc.)
-make install
-
-# Build with xtask gen-image — no external SDK download needed.
-make build
-```
-
-### Post-boot CC-PD client
-
-Once agentOS is running in QEMU, use `agentctl` to inspect and control guests
-via the CC-PD socket:
-
-```bash
-make -C tools/agentctl
-
-# List running guest OS instances
-./tools/agentctl/agentctl --batch list-guests
-
-# Query a specific guest
-./tools/agentctl/agentctl --batch guest-status <handle>
-
-# Snapshot a guest
-./tools/agentctl/agentctl --batch snapshot <handle>
-```
-
-Run `./tools/agentctl/agentctl --help` for the full command reference.
-
-## Project Structure
+## Project structure
 
 ```
-agentos/
-├── kernel/agentos-root-task/  # seL4 root task, PD code, IPC contracts
-├── kernel/freebsd-vmm/        # FreeBSD VMM support code
-├── services/                  # host-side service models and prototypes
-├── libs/                      # shared C/Rust support libraries
-├── userspace/                 # Rust SDK and userspace service crates
-├── tools/                     # host tools such as agentctl and image helpers
-├── xtask/                     # Rust automation for build/test/fetch flows
-├── tests/                     # host, contract, integration, and E2E tests
-├── docs/                      # documentation
-├── build/                     # generated images, sockets, logs, temp artifacts
-├── Makefile                   # top-level build/run/test entry point
-└── AGENTS.md                  # repository rules for agents and developers
+kernel/agentos-root-task/     root task, booted PD sources, IPC contracts
+  src/main.c                  boot: parse image, spawn PDs, map regions, park
+  src/system_desc_aarch64.c   compile-time PD descriptor table (pd_desc_t)
+  agentos.toml                PD bundle manifest (must match the descriptor)
+  include/contracts/          packed-struct IPC contracts, one header per PD
+kernel/loader/                seL4 loader
+platform/                     shared I/O platform
+  include/platform/           sDDF-shaped queue layouts (net, blk, serial), GPA translation
+  net-virt/                   net_virt PD, hub/loopback pump, VMM virtio-net glue
+  blk-virt/                   blk_virt PD, RAM-disk pump, VMM virtio-blk glue
+  serial-virt/                VMM virtio-console glue (library, not yet a PD)
+  guest-vmm/ guest-ram/       guest-neutral VMM runtime, bounds-checked GPA->HVA
+libvmm/                       vendored libvmm (UNSW): vCPU, vGIC, virtio device models
+services/                     driver PD sources: net-service (net_pd), serial-mux (serial_pd), vibe-engine
+guest-profiles/               versioned TOML guest personalities (buildroot, ubuntu, freebsd, ...)
+guest-scenarios/              multi-guest compositions (dual-release.toml)
+boards/                       per-board build config (qemu-aarch64, qemu-x86_64, rpi5, intel-nuc, ...)
+xtask/                        Rust task runner: build image, QEMU tests, guest fetch, release
+tests/                        host suites, source lint, guest-path tests, e2e scripts
+tools/                        agentctl and Rust generators (gen-abi, gen-sdf, sign-wasm, ...)
+skills/                       text-only operating notes per block (sel4-platform, sddf-net, ...)
+docs/                         TCB.md, ROADMAP.md, RELEASES.md, guides; see docs/README.md
 ```
 
-## Development Status
+`contracts/`, `userspace/`, `libs/rust-pd`, `examples/`, and `manifests/` hold
+host-side models, simulation crates, and older agent-facing contract drafts.
+None of them runs on the booted target.
 
-agentOS is **alpha**. Many subsystems exist as host-validated scaffolding rather
-than proven bare-metal behavior. To avoid overstating maturity, every subsystem
-below is labeled by **proof level**, not by "done / not done".
+## Proof levels and status
 
-### Proof-level legend
+Host tests stub seL4 IPC and cannot be cited as proof of I/O. Only a booted
+image asserted by an automated QEMU test can.
 
 | Level | Meaning |
 |-------|---------|
-| **boot-proven** | Exercised on a booted seL4 target under QEMU (or hardware) and asserted by an automated E2E/boot test. |
-| **target-tested** | Built into the seL4 target image and validated by a test that runs against the target, but not full end-to-end boot of the feature. |
-| **host-tested** | Validated only by host-compiled tests (`-DAGENTOS_TEST_HOST`) where seL4/Microkit IPC is stubbed. Proves contract/logic shape, **not** production IPC or hardware behavior. |
-| **stubbed** | Code links and returns a defined value, but the real behavior is a placeholder / `not implemented` / no-op. |
-| **planned** | Described in design docs; little or no implementation yet. |
+| **guest-proven** | A guest OS booted under agentOS and an automated test asserted real I/O through the emulated device and the virtualizer PD. |
+| **boot-proven** | The PD is in the booted image and a QEMU test waited for its marker. Proves load and reachability, not I/O. |
+| **host-tested** | Compiled with `-DAGENTOS_TEST_HOST`; seL4 IPC is a stub. Logic only. |
+| **lint** | `tests/platform/lint_source_invariants.c` checks the checked-in topology for a `docs/TCB.md` invariant. Not a test. |
+| **target** | Described in `docs/TCB.md` or `docs/ROADMAP.md`; not in the booted image. |
 
-> Per the project's proof policy (`PLAN.md`): host-only mocks may exist, but they
-> **cannot** be cited as proof of production IPC or bare-metal behavior. When a
-> level below is uncertain, the more conservative label is used.
+| Claim | Level | Evidence |
+|-------|-------|----------|
+| Root task boots and spawns the PD set, AArch64 | boot-proven | `make test TARGET_ARCH=aarch64 GUEST_OS=none` waits for `agentOS boot complete`; CI `Build & boot test` |
+| Root task boots, x86_64 | boot-proven (reduced topology, no guest) | `make test TARGET_ARCH=x86_64 GUEST_OS=none` waits for `[rt] boot complete` with no `[rt] FAULT` |
+| Emulated virtio-net through `net_virt` | guest-proven | `make test-guest-net` (Buildroot); CI `Guest virtio-net packet proof` |
+| Emulated virtio-blk through `blk_virt` | guest-proven | `make test-guest-blk` (Buildroot); CI `Guest virtio-blk I/O proof` |
+| Emulated virtio-console (library path) | guest-proven | `make test-guest-console` (Ubuntu initramfs) |
+| Ubuntu on agentOS net + blk + console only, host-backed | guest-proven | `make test-ubuntu-virtio`; CI `Ubuntu agentOS VirtIO net + blk + console proof` |
+| Ubuntu Casper live filesystem to login | nightly qualification, not a per-push gate | `make test-ubuntu-live`; `ubuntu-live-nightly.yml` |
+| Concurrent Ubuntu + FreeBSD with key-only SSH | acceptance gate, run on demand | `make demo-test` |
+| Ubuntu desktop over an SSH tunnel (RFB frame) | experimental | `make demo-desktop-test`; `docs/desktop-demo.md` |
+| Console virtualizer as its own PD | target | `docs/TCB.md` |
+| Native agent attached to `net_virt`/`blk_virt` queues | target | `kernel/agentos-root-task/src/native_net_client.c` is a host-tested client of the older `net_pd` raw contract; nothing native attaches to a virtualizer yet |
+| x86_64 guest execution, virtio-gpu/input, Debian baseline | target | `docs/ROADMAP.md` 0.3 and 0.4 |
+| Guest snapshot/restore, live migration | not implemented | `vm_manager.c` returns not-implemented |
+| WASM agents, capability hot-swap, agent-facing services (CapStore, MsgBus, ToolSvc, ModelSvc) | museum / host models only | Not in the booted image; see `docs/TCB.md` |
 
-### Subsystem status
-
-| Subsystem | Proof level | Evidence / notes |
-|-----------|-------------|------------------|
-| Top-level Makefile (`setup`/`demo`/`build`/`test`/E2E) | host-tested | Build/run orchestration; not a runtime subsystem |
-| Raw seL4/Microkit boot (AArch64, x86_64) | boot-proven | `xtask qemu-test` and `tests/end_to_end_boot_test.sh` wait for boot markers; RISC-V build path exists but is not regularly boot-asserted |
-| Linux/Ubuntu guest boot | boot-proven | `make demo-test` boots Ubuntu beside FreeBSD and proves authenticated SSH; `make test-guest-login` separately proves the CC-PD serial-console path |
-| FreeBSD 15.0 guest boot | boot-proven | `make demo-test` boots FreeBSD beside Ubuntu and proves authenticated SSH |
-| Guest VMM multiplexer (slot create/switch/list/status) | target-tested | VMM contract + slot lifecycle exercised; per-guest VMM slots coordinated (`470679f`) |
-| Guest snapshot / restore | stubbed | `vm_manager.c`: `SNAPSHOT/RESTORE: not implemented (Phase 1)`; `cc_pd.c` boot-guest snapshot returns `CC_ERR_RELAY_FAULT` |
-| Guest live-migrate | planned | `MSG_VIBEOS_MIGRATE` defined in contract; no target-validated implementation |
-| Guest virtual IRQ injection | stubbed | `vm_manager.c` `vmm_inject_irq` logs `(stub)`; real `virq_inject` via libvmm is a TODO |
-| Dynamic guest CREATE/LIST/DESTROY via vibe_engine | host-tested | On AArch64 the build links `vmm_mux_stub.c`; vibe_engine surfaces dynamic guests as "phantom" `RUNNING` because no real VM boots (`e70d955`). Lifecycle UX works end-to-end through CC-PD against stubbed VM backing only. |
-| serial-mux / serial PD | boot-proven | Guest console login flows through CC-PD over the serial path (`make test-guest-login`) |
-| Emulated virtio-net / net-service | target-tested | `make test-guest-net` boots Buildroot, reaches `DRIVER_OK`, and requires a guest packet through the agentOS virtualizer; host contract tests provide additional logic coverage |
-| Emulated virtio-blk / block-service | target-tested | `make test-guest-blk` boots Buildroot and requires a guest block request through the agentOS virtualizer; host contract tests provide additional logic coverage |
-| usb-service | stubbed | `usb_pd.c` runs in "stub mode" (simulated HID device) unless built with `AGENTOS_USB_PD` and real MMIO is wired |
-| timer-service | host-tested | Host contract tests (`tests/contracts/timer_test.c`) |
-| entropy-service | host-tested | `services/entropy-service/entropy_svc.c` + contract; not target-validated |
-| CC-PD host API (list/status/console) | boot-proven | Unix socket bridge at `build/cc_pd.sock`; list/status/console-drain proven by guest-login E2E |
-| CC-PD snapshot relay | stubbed | Returns `CC_ERR_RELAY_FAULT` for the boot guest (snapshot not implemented) |
-| VibeOS lifecycle API (`VOS_*`) | host-tested | Contract tests build with `-DAGENTOS_TEST_HOST` (`make test-vibeos-contract`, `tests/api/test_vibeos*.c`); create/destroy/list/status logic proven on host, not on target |
-| vibe-engine WASM hot-swap | host-tested | `tests/integration/vibe_hotswap_test.c` exercises read/probe paths only; actual WASM propose+swap needs a mapped staging region (hardware-dependent) |
-| Tracing (trace_recorder PD) | host-tested | 512-entry ring with START/STOP/QUERY/DUMP; covered by host contract tests, not boot-asserted |
-| Host integration/contract test suite | host-tested | `make test-integration` runs host-compiled tests with stubbed IPC |
-| Build artifact hygiene | host-tested | Images, sockets, logs, temp files under `build/` |
-| External GUI | Separate project | Lives in `../agentos_gui`; not part of this repo |
-
-## Philosophy
-
-agentOS is built on a few core beliefs:
-
-1. **Agents deserve their own OS.** Running on Linux is running on someone else's OS, designed for someone else's needs.
-
-2. **Security is not optional.** Formal verification, capability-based isolation, and hardware-enforced boundaries are the minimum bar for a system where autonomous agents operate.
-
-3. **Agents should design their environment.** The hardest part of building agent infrastructure is that humans are guessing at what agents need. Let agents figure it out themselves.
-
-4. **Boot it or it doesn't count.** An "agent OS" that's a Python package is an agent library. agentOS boots.
-
-## CUDA Compute Offload
-
-> **Proof level: host-tested / planned.** The PTX-in-WASM extraction and slot
-> bookkeeping are exercised on the host. On QEMU/RISC-V (no GPU) the
-> gpu_scheduler is bookkeeping only; real `nvrtc` JIT + CUDA-context binding on
-> Sparky GB10 (Blackwell) is **planned** and not boot-proven here.
-
-agentOS is designed to support GPU kernel offload via CUDA PTX embedded in WASM modules.
-
-### How it works
-
-1. **Embed PTX in WASM**: Add a custom section named `agentos.cuda` to any WASM module. The section payload is a raw PTX source file (must begin with `.version`).
-
-2. **Submit via VibeEngine**: When an agent submits a WASM module with this section, VibeEngine automatically extracts and validates the PTX during `OP_VIBE_VALIDATE`.
-
-3. **gpu_scheduler PD**: On `OP_VIBE_EXECUTE`, VibeEngine notifies the `gpu_scheduler` protection domain (priority 160, passive). The scheduler claims one of 4 static GPU slots.
-
-4. **On Sparky GB10 (Blackwell)**: The gpu_scheduler would JIT-compile the PTX via `nvrtc` and bind it to a CUDA context on the slot. On QEMU/RISC-V (no GPU), it's bookkeeping only.
-
-### Rust SDK
-
-```rust
-use agentos_sdk::cuda::CudaKernel;
-
-let ptx = b".version 7.5\n.target sm_90\n.address_size 64\n\
-            .visible .entry matmul(.param .u64 A, .param .u64 B, .param .u64 C) {\n\
-                ret;\n}\n".to_vec();
-
-let kernel = CudaKernel::new(ptx, "matmul".to_string());
-kernel.validate()?;   // Check PTX before submitting
-kernel.submit(0)?;    // Submit to GPU slot 0
-// ... kernel runs on GPU ...
-CudaKernel::complete(0)?; // Release slot
-```
-
-### Channel topology
-
-```
-vibe_engine (CH_GPU=2) ──notify──► gpu_scheduler (CH_VIBE=0)
-controller  (CH=51)    ──ppcall──► gpu_scheduler (CH_CTRL=1)
-```
-
----
-
-## FreeBSD VM Guest
-
-agentOS stages and boots **FreeBSD 15.0 AArch64** as a virtual machine guest
-under the seL4 hypervisor path (proof level: **boot-proven** —
-`make demo-test` boots it beside Ubuntu and proves authenticated SSH). The same
-CC-PD API surface used by Ubuntu enumerates the guest, drains serial output,
-and injects console input.
-
-seL4 runs at **EL2** (ARM hypervisor mode) — it IS the hypervisor. No separate hypervisor layer needed.
-
-### Boot sequence
-
-```
-seL4 (EL2)
-  └─► freebsd_vmm PD (libvmm)
-        ├─► FreeBSD kernel + agentOS FDT copied into guest RAM
-        └─► vCPU enters the FreeBSD kernel (EL1)
-              └─► virtio-blk mounts the staged 15.0 live media
-```
-
-### VM Multiplexer
-
-The generic VMM contract models up to 4 guest slots. The FreeBSD path uses the
-same slot lifecycle vocabulary as the Ubuntu path. CREATE/SWITCH/STATUS/LIST and
-single-guest boot are exercised by `make test-guest-login` and the E2E targets
-(**boot-proven** / **target-tested**). Note that `SNAPSHOT`/`RESTORE` and virtual
-IRQ injection in `vm_manager.c` are **stubbed** ("not implemented (Phase 1)"),
-and on AArch64 dynamic CREATE via vibe_engine currently links a VMM stub
-(dynamic guests appear as "phantom" `RUNNING`). The opcode table below describes
-the contract, not a fully boot-proven implementation of every opcode:
-
-| Opcode | Operation | Args | Returns |
-|--------|-----------|------|---------|
-| `0x10` | `OP_VM_CREATE` | — | `slot_id` (0-3) or `0xFF` |
-| `0x11` | `OP_VM_DESTROY` | `mr[0]=slot_id` | `0` ok / `1` error |
-| `0x12` | `OP_VM_SWITCH` | `mr[0]=slot_id` | `0` ok / `1` error |
-| `0x13` | `OP_VM_STATUS` | — | `mr[0..3]` = state per slot |
-| `0x14` | `OP_VM_LIST` | — | count + `(slot_id<<8\|state)` per slot |
-
-**Slot states:** `FREE(0)` -> `BOOTING(1)` -> `RUNNING(2)` <->
-`SUSPENDED(3)` -> `HALTED(4)` / `ERROR(5)`
-
-Console focus follows the selected guest handle through CC-PD.
-
-### Quick start
-
-```bash
-# Install build dependencies and the shared Microkit SDK
-make setup
-
-# Stage FreeBSD 15.0 assets under build/guest-images
-make fetch-guest GUEST_OS=freebsd
-
-# Build and boot the FreeBSD guest path
-make run GUEST_OS=freebsd
-```
-
-### Inspecting the Guest
-
-Once agentOS is running, inspect the FreeBSD guest through the CC-PD reference
-consumer:
-
-```bash
-make -C tools/agentctl
-./tools/agentctl/agentctl --batch list-guests
-./tools/agentctl/agentctl --batch guest-status 0
-```
-
-### Memory layout
-
-Each VMM has an isolated guest VSpace. In the dual demonstration both guests
-see the conventional RAM GPA at `0x40000000`, while their VMM aliases are
-disjoint:
-
-```
-Guest view:
-  FreeBSD GPA: 0x40000000 - 0x4fffffff  (256 MB)
-  Linux GPA:   0x40000000 - 0x7fffffff  (1 GB)
-
-VMM aliases:
-  FreeBSD HVA: 0x80000000 - 0x8fffffff
-  Linux HVA:   0xc0000000 - 0xffffffff
-```
-
-The repeated GPA does not overlap because each guest has its own VSpace.
-
-### Why FreeBSD?
-
-- BSD license aligns with seL4's formal verification story
-- **Jails** map naturally to seL4 capability domains (Phase 3 roadmap)
-- `pf` firewall ruleset = capability policy layer
-- ZFS + GEOM: a principled storage stack for agentOS's BlobSvc
-- bhyve inside FreeBSD = agents can *nest* hypervisors within agentOS
-
-See [`docs/freebsd-vm-guest.md`](docs/freebsd-vm-guest.md) for the full design doc.
-
----
+`make gate` is the OS-claim gate: `test-host`, both `GUEST_OS=none` boots, and
+`gate-guest-io` (`test-guest-net`, `test-guest-blk`, `test-guest-console`).
 
 ## Roadmap and releases
 
-- [`docs/ROADMAP.md`](docs/ROADMAP.md) defines the 0.2 desktop proof, 0.3
-  graphics path, 0.4 x86 VMM, 0.5 x86 graphical guest, and 1.0 qualification
-  boundaries.
-- [`docs/RELEASES.md`](docs/RELEASES.md) defines the evidence-bound release
-  protocol and gate matrix.
-- [`docs/presentations/agentos-systems-security/deck.md`](docs/presentations/agentos-systems-security/deck.md)
-  is the editable, claim-labeled narrative for OS and security experts.
-- `make presentation-render PRESENTATION_EDITION=X.Y.Z` renders that source as
-  a PDF plus checksum-bearing QA receipt under `build/presentations/`.
+- [`docs/ROADMAP.md`](docs/ROADMAP.md): 0.3 Debian baseline and guest
+  graphics, 0.4 x86 VMM, 0.5 persistent x86 desktop, 0.6 Omarchy, 1.0
+  dual-architecture qualification, and the trust-baseline corrective actions.
+- [`docs/RELEASES.md`](docs/RELEASES.md): evidence-bound release protocol
+  (`make release`, `release-prepare`, `release-check`, `release-publish`,
+  `release-verify`).
+- [`CHANGELOG.md`](CHANGELOG.md): release notes; current line is v0.2.x.
+- [`PLAN.md`](PLAN.md): active implementation sequencing.
 
----
+## FreeBSD guest
+
+FreeBSD 15.0 AArch64 boots as a guest with the same emulated virtio devices
+and the same VMM as Linux; `make demo-test` proves it beside Ubuntu.
+[`docs/freebsd-vm-guest.md`](docs/freebsd-vm-guest.md) has the standalone
+commands; its architecture diagram predates the current PD set.
 
 ## Contributing
 
-agentOS is in early (alpha) development. The design is stable; the implementation
-is growing and much of it is still host-tested scaffolding (see the proof-level
-status table above). Contributions welcome in:
-
-- seL4/Microkit integration and IPC contract coverage
-- libagent SDK implementation
-- Generic device PD and VMM integration
-- CC-PD API and E2E tests that prove guest OS behavior
-- Documentation and tutorials
+- Language policy: first-party code is **C, Rust, or Assembly** — target code,
+  host tools, tests, generators, and skill helpers alike. No Python,
+  JavaScript, Go, Zig, or HTML/CSS anywhere in the repository, including
+  vendored code. `make policy-check` enforces this.
+- No human UI in this repository. `agentctl` (CLI) is the only in-tree
+  consumer; GUIs live in external repositories.
+- Contracts before callers: IPC contracts under
+  `kernel/agentos-root-task/include/contracts/`, queue layouts under
+  `platform/include/platform/`.
+- Do not extend museum PDs (`docs/TCB.md`). Do not pass QEMU devices through
+  to guests. Do not add guest drivers for a class that has a virtualizer.
+- Run `make test-host` before pushing; OS-level claims need `make gate`.
+- Tasks are tracked with `mac task` (project `agentos`), not GitHub issues or
+  TODO lists. See `AGENTS.md`.
+- Developer guide: [`docs/DEVELOPER_GUIDE.md`](docs/DEVELOPER_GUIDE.md).
 
 ## License
 
-BSD 2-Clause. See [LICENSE](LICENSE).
+BSD 2-Clause. See [LICENSE](LICENSE). `libvmm/` carries its own licenses
+(see `libvmm/LICENSES/`).
 
-## Acknowledgments
-
-Built on [seL4](https://sel4.systems/) by the Trustworthy Systems group at CSIRO's Data61. The formally verified foundation that makes this possible.
-
----
-
-*"Hey Rocky, watch me pull an operating system out of my hat!"*  
-*"That trick never works!"*  
-*"This time for sure!"*  
-*[boots successfully]* 🫎
+Built on [seL4](https://sel4.systems/) and
+[libvmm](https://github.com/au-ts/libvmm) from the Trustworthy Systems group,
+UNSW.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,417 @@
+# agentOS Developer Guide
+
+For people building on agentOS: adding a protection domain, a virtualizer, a
+guest profile, or a native agent. Read `docs/TCB.md` first; it is binding.
+`CLAUDE.md` and `AGENTS.md` hold the rules this guide assumes.
+
+Paths are relative to the repository root. `RT` below means
+`kernel/agentos-root-task`.
+
+## 1. Boot flow
+
+```
+QEMU -device loader
+  -> kernel/loader            seL4 loader: places the kernel and agentos.img
+  -> seL4                     EL2; never modified
+  -> root task                RT/src/main.c, entry RT/src/start_aarch64.S
+       parses agentos.img     format: docs/sel4-loader-format.md
+       reads the descriptor   RT/src/system_desc_aarch64.c (pd_desc_t table)
+       for each PD in order:  allocate CSpace/VSpace, load ELF from the
+                              embedded PD bundle, mint init EPs, bind IRQs,
+                              map device frames and shared regions, set
+                              priority, start the thread at _start
+       parks in seL4_Wait     no policy after spawn
+  -> PDs                      nameserver first, then the rest by table order
+```
+
+`make build` runs `RT/Makefile`, which compiles every PD ELF in its `IMAGES`
+list, packs the ELFs named in `RT/agentos.toml` into a `.pd_bundle` with
+`cargo xtask gen-pd-bundle`, links that into `root_task.elf`, and produces
+`build/<board>/agentos.img` with `cargo xtask gen-image`.
+
+**Parity rule.** `RT/agentos.toml` (what is bundled) and
+`RT/src/system_desc_aarch64.c` (what is spawned) must name the same PD set.
+A bundle entry with no descriptor row is dead weight that never starts; a
+descriptor row with no bundle entry fails at ELF load. The Makefile appends
+`guest_vmm_secondary`, `fault_inject`, and `event_bus` + `test_runner` to
+both for the image variants that need them. `make lint-source` fails if a
+retired PD reappears in the default descriptor.
+
+The `agentOS boot complete` marker that `make test` waits for is printed by
+`cc_pd`, the lowest-priority PD in the image, right before it enters its
+request loop.
+
+## 2. Declaring a PD
+
+A PD is one row in the `pd_desc_t` table in `RT/src/system_desc_aarch64.c`.
+The type is in `RT/include/system_desc.h`:
+
+| Field | Meaning |
+|-------|---------|
+| `name`, `elf_path` | PD name (also its `agentos.toml` name) and `<name>.elf` in the bundle |
+| `stack_size`, `cnode_size_bits` | stack bytes (page-aligned) and log2 of the PD's CNode size |
+| `priority` | seL4 priority. Providers run above their clients (see the priority DAG comment at the top of the descriptor) |
+| `self_svc_id` | `SVC_ID_*` of this PD's own listen endpoint, or 0. The root task mints it at `PD_CNODE_SLOT_SELF_EP` and passes that slot as the first argument to `_start` |
+| `init_eps[]` | `{ SVC_ID_x, PD_CNODE_SLOT_x_EP }` pairs: badged endpoint caps to other PDs, minted into this PD's CNode at boot. This is the capability graph; a PD can only call what is listed here |
+| `irqs[]` | `irq_desc_t { irq_number, ntfn_badge, name }`; the root task calls `seL4_IRQControl_Get` and places the handler cap at `PD_IRQHANDLER_SLOT_BASE + i`. Driver PDs only |
+| `device_frames[]` | `device_frame_desc_t { paddr, size_bits, cnode_slot, name }`; the MMIO frame. Driver PDs only, one owner per frame |
+| `memory_regions[]` | `memory_region_desc_t { vaddr, size, name }`; 2 MB-aligned regions such as `guest_ram` |
+
+The endpoint for a service is allocated once by `ep_alloc_for_service()`
+(`RT/src/ep_alloc.c`) and minted with a per-client badge into each client's
+CNode, so the server can tell callers apart by badge. `SVC_ID_*` and
+`PD_CNODE_SLOT_*` constants live in `RT/include/system_desc.h`; add new ones
+there.
+
+Two worked rows in the descriptor:
+
+- `serial_pd` (a driver): `irqs = { 33, "pl011-uart" }`,
+  `device_frames = { 0x09000000, 12 bits, "pl011-mmio" }`, priority 225.
+- `net_virt` (a virtualizer): `irq_count = 0`, `device_frame_count = 0`,
+  priority 205 (below `net_pd` at 207, which it calls), `init_eps` holding
+  the nameserver, log_drain, serial, `net_pd`, and guest VMM endpoints.
+
+**Shared regions are mapped by name in `main.c`**, not by descriptor field.
+`RT/src/main.c` allocates the shared net frame and the shared block region
+once and maps them into the PDs whose names it checks (`net_pd`, `net_virt`,
+and every guest VMM for the net frame at `AGENTOS_NET_SHARED_VA`; the block
+region likewise; the serial transfer page into `serial_pd`, `log_drain`,
+`cc_pd`, `net_virt`, `test_runner`, and the VMMs). When a new PD needs one of
+these regions, add its name to the relevant condition in `main.c` and record
+the mapping in `docs/TCB.md`. Nothing else may map a device frame.
+
+## 3. PD skeleton
+
+Every service PD is linked with `RT/src/pd_entry.c`, which defines `_start`:
+it points `__sel4_ipc_buffer` at the root-task-mapped IPC page
+(`PD_IPC_BUF_VA`) and calls
+
+```c
+void pd_main(seL4_CPtr my_ep, seL4_CPtr ns_ep);
+```
+
+`my_ep` is the CNode slot of the PD's own listen endpoint (from
+`self_svc_id`), `ns_ep` the nameserver endpoint slot. A missing `pd_main`
+fails the link on purpose.
+
+The shape used by `platform/net-virt/net_virt.c`:
+
+```c
+void pd_main(seL4_CPtr my_ep, seL4_CPtr ns_ep)
+{
+    agentos_log_boot("net_virt");
+    /* reset local state */
+    register_with_nameserver(ns_ep);        /* OP_NS_REGISTER Call */
+    nv_puts("[net_virt] READY: ...\n");     /* serial_log marker */
+    net_virt_run(my_ep);                    /* seL4_Recv loop, never returns */
+}
+```
+
+The loop is a plain `seL4_Recv(ep, &badge)`; the message label selects
+between a Call to reply to (`seL4_Reply`, or `seL4_Send` on the reply cap
+under MCS) and a notification to service. Unknown labels are ignored.
+
+**Logging.** Non-driver PDs must never map the UART. Use `serial_log_t` from
+`RT/include/serial_log.h`: a line buffer written into the shared serial
+transfer page and flushed to `serial_pd` with the `MSG_SERIAL_*` contract.
+`log_drain_write` is the generic path, but its `MSG_SERIAL_WRITE` request
+layout does not match `serial_pd`'s handler, so generic PD log output is
+silent on the release kernel (see `CHANGELOG.md`, Known limitations). Any
+marker a test must see goes through `serial_log`.
+
+Build rules: add `$(BUILD_DIR)/<pd>.o` and `$(BUILD_DIR)/<pd>.elf` rules to
+`RT/Makefile`, add `<pd>.elf` to `IMAGES`, and add a `PD_<PD>_SRCS` line for
+the shared objects it links (`src/m3_bare_metal.c src/log.c` at minimum).
+`net_virt` is the template: its sources are under `platform/net-virt/` and
+compiled with the plain PD toolchain, with a `.pd.o` suffix keeping the pump
+object apart from the copies `vmm.mk` compiles into the VMMs.
+
+## 4. Contracts
+
+Every live PD exposes one contract before it has callers.
+
+- IPC control contracts: `RT/include/contracts/<pd>_contract.h`.
+- Queue layouts for bulk data: `platform/include/platform/*_layout.h`
+  (`net_layout.h`, `blk_layout.h`, `serial_layout.h`). These headers have no
+  seL4 dependency so host tests can compile them.
+
+A contract header contains a version constant, opcode/label constants,
+status codes, and packed request/reply structs whose size is asserted where
+they are used. `RT/include/contracts/net_virt_contract.h` is the worked
+example:
+
+```c
+#define NET_VIRT_CONTRACT_VERSION   1u
+#define NET_VIRT_OP_ATTACH          0x2201u   /* Call, VMM -> net_virt */
+#define NET_VIRT_EVENT_KICK         0x2210u   /* NBSend, VMM -> net_virt */
+
+typedef struct __attribute__((packed)) {
+    uint32_t version;    /* NET_VIRT_CONTRACT_VERSION */
+    uint32_t client_id;  /* queue stride index */
+    uint32_t vmm_slot;   /* NET_VIRT_VMM_SLOT_* */
+} net_virt_attach_req_t;
+
+typedef struct __attribute__((packed)) {
+    uint32_t status;     /* NET_VIRT_OK / NET_VIRT_ERR_* */
+    uint32_t version;
+    uint32_t hw_state;   /* NET_VIRT_HW_NONE / NET_VIRT_HW_NET_PD */
+    uint8_t  mac[6];
+    uint8_t  _pad[2];
+} net_virt_attach_reply_t;
+```
+
+Payloads travel in `sel4_msg_t.data` with the opcode in the message label.
+The header comment documents the transport (which labels are Calls, which are
+NBSends) and the signalling protocol. `blk_virt_contract.h` follows the same
+pattern with `BLK_VIRT_OP_ATTACH`, `BLK_VIRT_EVENT_KICK`, and
+`BLK_VIRT_EVENT_RESP_READY`.
+
+`cargo xtask gen-abi` validates per-PD opcode tables against
+`tools/abi_spec.toml` and fails on collisions.
+
+## 5. Notifications vs. IPC
+
+Bulk data never crosses IPC. The rule is:
+
+- **One Call to attach.** The client (a VMM or a native agent) does a single
+  `ATTACH` Call to the virtualizer, naming its queue stride (`client_id`) and
+  the endpoint it wants events on (`vmm_slot`).
+- **Data in sDDF-shaped queues** in a shared region mapped by the root task
+  into the client and the virtualizer (`AGENTOS_NET_SHARED_VA`, one 512 KB
+  stride per client in a 2 MB frame for net; the shared block region for
+  blk).
+- **Kicks are `seL4_NBSend`** with a label and no payload. The sender never
+  blocks. A kick that lands while the receiver is not in `Recv` is dropped,
+  so the protocol makes every kick re-sendable:
+  - The consumer owns a `consumer_signalled` flag per queue (sDDF style;
+    `tx_active.consumer_signalled` and `rx_free.consumer_signalled` for net,
+    the `req_consumer_signalled` word for blk). The consumer sets it to 1
+    while draining and to 0 right before it blocks.
+  - The producer kicks only when the queue is non-empty and the flag is 0.
+    The producer never writes the flag, so a lost kick is repeated on the
+    next guest MMIO exit.
+  - Before blocking, the virtualizer rescans every queue and polls the driver
+    once more, so a lost notification from the driver costs latency, not
+    data.
+- **The virtualizer alone speaks the driver's contract.** `net_virt` holds
+  the only `net_pd` endpoint and does `RAW_SEND`/`RAW_RECV` Calls; `net_pd`
+  NBSends `RX_READY` to `net_virt`, never to a VMM. No VMM holds a `net_pd`
+  endpoint. `blk_virt` likewise holds the only `virtio_blk` endpoint and is
+  the only non-driver PD that maps the bounded DMA window.
+
+`tests/platform/lint_source_invariants.c` (`inv2:` checks) fails the build if
+a VMM row acquires a driver endpoint or a virtualizer row acquires a device
+frame or IRQ.
+
+## 6. Adding a virtualizer or driver PD
+
+Use the `net_virt` change as the template:
+
+```bash
+git log --oneline origin/main -- platform/net-virt
+git show --stat 98172dd5      # net_virt: make the network virtualizer a real PD (#123)
+```
+
+The order that worked:
+
+1. **Layout first.** Define or reuse the queue layout in
+   `platform/include/platform/<class>_layout.h`, with static asserts on
+   offsets and strides. Write a host-testable pump over it
+   (`platform/<class>-virt/<class>_virt_pump.c`) and a host test
+   (`tests/platform/test_<class>_virt_pump.c`).
+2. **Contract.** Add `RT/include/contracts/<class>_virt_contract.h` with a
+   version, `ATTACH`, `KICK`, and any event labels, plus packed structs.
+3. **PD source.** `platform/<class>-virt/<class>_virt.c` with `pd_main`,
+   nameserver registration, a `serial_log` READY marker, and the `Recv` loop
+   from section 3.
+4. **Descriptor row** in `RT/src/system_desc_aarch64.c`: no IRQs, no device
+   frames, `self_svc_id` set, `init_eps` listing the driver endpoint and each
+   client VMM endpoint, priority between the driver (above) and the VMMs it
+   serves. Add the `SVC_ID_*` and `PD_CNODE_SLOT_*` constants to
+   `RT/include/system_desc.h`.
+5. **Manifest.** Add the PD to `RT/agentos.toml` (same name, priority noted
+   for parity).
+6. **Shared region.** In `RT/src/main.c`, add the PD name to the condition
+   that maps the class's shared region. Remove the driver endpoint from the
+   VMM rows so the VMM can no longer bypass the virtualizer.
+7. **Client side.** Change the VMM glue (`platform/<class>-virt/vmm_virtio_<class>.c`)
+   to do one `ATTACH` Call and then only `NBSend` kicks; drop any per-item
+   IPC to the driver.
+8. **Build.** `RT/Makefile`: object and ELF rules, `IMAGES`, `PD_*_SRCS`;
+   `RT/vmm.mk` if the VMM side changed.
+9. **Lint.** Add `inv2:` checks to `tests/platform/lint_source_invariants.c`
+   for the new PD: exists in topology and manifest, no device caps, holds the
+   driver EP, VMMs hold no driver EP, driver holds no VMM EP.
+10. **Proof.** Add or extend the guest proof markers in `xtask/src/cmd_test.rs`
+    so `make test-guest-<class>` and `make test-ubuntu-virtio` require the
+    virtualizer's host-backed markers. Update `docs/TCB.md` ("How I/O flows
+    today", invariant 2) and `CHANGELOG.md`.
+
+For a **driver PD** the row differs: exactly one `device_frames` entry and
+one `irqs` entry, a `self_svc_id`, and no client endpoints other than the
+virtualizer's. `serial_pd` (`services/serial-mux/serial_pd.c`) and `net_pd`
+(`services/net-service/net_pd.c`) are the examples. Under QEMU the "device"
+is a QEMU virtio-mmio device on a bus that is never advertised to guests
+(bus.8 block, bus.16 net, bus.2 control console).
+
+Do not add `MSG_*_SEND`-style opcodes that carry payload through IPC
+registers as a substitute for queues; that is the pattern invariant 2 exists
+to remove.
+
+## 7. Adding a guest profile
+
+Guest identity is data (`docs/guest-profiles.md`). A profile is a TOML file
+under `guest-profiles/` that `cargo xtask guest-profile` validates and
+compiles into a fixed 640-byte manifest consumed by the VMM.
+
+```text
+schema = 2
+id = "buildroot-proof-aarch64"
+status = "runtime"                  # abstract | planned | runtime
+extends = "linux-base.toml"
+aliases = ["buildroot", "linux"]    # what GUEST_OS=<alias> resolves to
+
+[boot]           command_line, optional media_initrd_path
+[artifacts.*]    kernel / dtb / initrd: source, cache path, sha256, max_bytes
+[placements.*]   ram_size, dtb_load_address per slot placement
+[[host.acquire]] bounded acquisition recipe (download, extract, convert)
+[host.build]     DTB template merge (linux-virtio-overlay.dts.in)
+[host.qemu]      machine, memory, host media, bus numbers
+[host.console]   expect rules: markers, sends, retry ceilings
+[[host.test]]    assert-virtio devices and scope (emulated | host-backed)
+```
+
+`runtime` profiles need pinned SHA-256 for every artifact. The compiler
+rejects unknown fields, unbounded text, absolute or `..` paths, and artifacts
+outside guest RAM. Recipe actions and DTB adapters come from closed Rust
+whitelists in `xtask/src/`; the target never interprets TOML.
+
+Steps:
+
+1. Copy the nearest profile (`buildroot.toml`, `ubuntu-e2e.toml`,
+   `freebsd.toml`, or `debian.toml`) and set `id`, `aliases`, artifacts, and
+   recipes. Start with `status = "planned"` until the hashes are pinned.
+2. `make guest-profile-check` (runs `cargo xtask guest-profile --check-all`
+   and the host profile tests).
+3. `make fetch-guest GUEST_PROFILE=<file>.toml`, then
+   `make run GUEST_PROFILE=<file>.toml`.
+4. For a proof, add `[[host.test]]` entries and run
+   `cargo xtask qemu-test --guest-os <alias> --assert-emulated-net` (or
+   `-blk`, `-console`, `--assert-agentos-virtio`).
+5. Multi-guest compositions go in `guest-scenarios/*.toml`
+   (`dual-release.toml` is `GUEST_OS=both`).
+
+Adding a profile does not add a VMM personality; there is one guest-neutral
+`guest_vmm.c`. Do not add guest drivers: guests boot stock kernels with
+in-tree virtio drivers and an FDT.
+
+## 8. Writing a native agent
+
+The target shape (`docs/TCB.md`): a native agent is a client of `net_virt`
+and `blk_virt`, exactly like a VMM backend. It gets a queue stride in the
+shared region, does one `ATTACH` Call, and moves frames or block requests
+through the sDDF queues with kicks. It owns no device and is not in the TCB.
+
+What exists today:
+
+- `RT/src/native_net_client.c` with `RT/include/native_net_client.h` and the
+  host test `tests/platform/test_native_net_client.c`. It is the client
+  described in the 0.2.0 changelog, but it speaks `net_pd`'s raw-frame
+  contract directly, which predates `net_virt`, and its only in-tree user
+  (`init_agent`) is no longer in the image. It is host-tested, not booted.
+- No native PD attaches to `net_virt` or `blk_virt` yet. PLAN.md step 9
+  (`task_ec992e5743354a538d1c3235a2e2c0da`) tracks it.
+
+To build one now, follow section 6 from the client side: a PD row with a
+`net_virt` (or `blk_virt`) endpoint in `init_eps`, its name added to the
+shared-region mapping condition in `main.c`, one `ATTACH` Call using the
+contract structs, then produce into `tx_active` / consume from `rx_active`
+with `platform/include/platform/net_layout.h` and kick per section 5.
+`platform/net-virt/vmm_virtio_net.c` is the reference client, minus the
+virtio emulation.
+
+WASM is a guest or agent binary format only; the interpreter in
+`RT/wasm3/` is museum code and is not a path to I/O.
+
+## 9. Testing policy
+
+| Layer | Command | Proves |
+|-------|---------|--------|
+| Policy | `make policy-check` | No forbidden languages or UI files; xtask formatted |
+| Source lint | `make lint-source` | `docs/TCB.md` invariants are visible in the compiled topology, headers, FDTs, profiles. Not a test |
+| Host tests | `make test-host` (includes the two above, `guest-profile-check`, `test-integration`) | Logic and struct shapes with seL4 IPC stubbed (`-DAGENTOS_TEST_HOST`, `tests/microkit.h`). Cannot be cited for I/O or IPC |
+| Boot | `make test TARGET_ARCH=aarch64 GUEST_OS=none`, same for `x86_64` | PDs load, root task parks. Stub VMM |
+| Guest I/O | `make test-guest-net`, `test-guest-blk` (Buildroot), `test-guest-console`, `test-ubuntu-virtio` (Ubuntu) | A guest saw the emulated device, reached `DRIVER_OK`, and real I/O crossed the virtualizer |
+| Gate | `make gate` | All of the above except `test-ubuntu-virtio`. Required before any OS-level claim |
+| Acceptance | `make demo-test` | Concurrent Ubuntu + FreeBSD with key-only SSH |
+| Nightly | `make test-ubuntu-live` | Casper live filesystem to login; not a per-push gate |
+
+A device-class claim needs its guest I/O assertion through the virtualizer,
+not a host test and not QEMU bus ownership. `xtask qemu-test` fails a
+host-backed proof that satisfied itself with the VMM-local loopback.
+
+CI (`.github/workflows/ci.yml`) runs host tests, both boot gates, the
+Buildroot net and blk proofs, and the Ubuntu VirtIO proof, and folds them
+into the `OS-claim gate (boot + guest net/blk/console proofs)` summary job.
+
+## 10. Language and UI policy
+
+First-party code is **C, Rust, or Assembly**: target code, host tools, tests,
+generators, and skill helpers. Python, JavaScript, TypeScript, HTML, CSS, Go,
+Zig, and other implementation languages are forbidden, including in vendored
+code. CMake and Make orchestrate builds; shell is CI glue and one-line
+wrappers. `cargo xtask policy-check` enforces this on every `make test-host`.
+
+No human UI in this repository: no dashboards, HTML, WebSocket terminals, or
+interactive TUIs. `tools/agentctl` (a CLI with structured stdout) is the only
+in-tree consumer of `cc_pd`; GUIs are external consumers of the contracts.
+
+## 11. What not to extend
+
+`docs/TCB.md`, section "What is not TCB (museum)", lists the PDs and ideas
+that must not be extended, given new opcodes, or "finished": `oom_killer`,
+`spawn_server`, `proc_server`, `term_server`, `app_manager`, `http_svc`,
+`wg_net`, `vibe_swap`/`swap_slot` as a path to I/O, `gpu_shmem` as a guest
+channel, CapStore/MsgBus/ModelSvc/ToolSvc as core OS, and the rest of that
+list. Their sources still compile from `RT/Makefile`'s `IMAGES` list but they
+are not bundled or booted. If you find one in your way, file a task; do not
+build on it.
+
+Also forbidden as architecture: passing a QEMU virtio device through to a
+guest, adding a guest-specific driver for a class that has a virtualizer,
+carrying bulk data through IPC registers, and cloud or LLM SDKs inside PDs.
+
+## 12. Tasks and workflow
+
+Work is tracked with `mac task` in project `agentos`, not GitHub issues or
+TODO lists:
+
+```bash
+mac task ready --project agentos --limit 10
+mac task show <id>
+mac task create "title" --project agentos --description-file=desc.txt --no-dispatch
+mac task close <id> --reason="..."
+```
+
+Commit messages follow `platform: <short description>` with a `Refs:
+<mac-task-id>` trailer (`AGENTS.md`). Before pushing: `make test-host` for
+any change, `make gate` for anything that touches a booted PD, and update
+`docs/TCB.md` if the booted PD set or an I/O path changed. Work is not done
+until `git push` succeeds.
+
+## Reference map
+
+| Topic | Where |
+|-------|-------|
+| Trust boundary, invariants, museum list | `docs/TCB.md` |
+| Root task boot | `RT/src/main.c`, `RT/src/start_aarch64.S`, `docs/sel4-loader-format.md` |
+| PD descriptor | `RT/src/system_desc_aarch64.c`, `RT/include/system_desc.h` |
+| PD entry and logging | `RT/src/pd_entry.c`, `RT/include/serial_log.h` |
+| IPC contracts | `RT/include/contracts/` |
+| Queue layouts, GPA translation | `platform/include/platform/` |
+| Virtualizers | `platform/net-virt/`, `platform/blk-virt/`, `platform/serial-virt/` |
+| VMM | `RT/src/guest_vmm.c`, `platform/guest-vmm/`, `libvmm/` |
+| Guest profiles | `docs/guest-profiles.md`, `guest-profiles/`, `guest-scenarios/` |
+| Test harness | `xtask/src/cmd_test.rs`, `tests/TARGET_TESTS.md` |
+| Roadmap and releases | `docs/ROADMAP.md`, `docs/RELEASES.md`, `PLAN.md` |
+| Operating notes per block | `skills/*/SKILL.md` |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,261 @@
+# agentOS Quick Start
+
+From a fresh clone to a booted agentOS under QEMU, then the guest I/O proofs.
+Every command below is a Makefile target or an `xtask` subcommand that exists
+in this tree; run `make help` for the full list.
+
+Supported hosts: macOS (Apple Silicon or Intel) and Linux (x86_64 or
+aarch64). FreeBSD hosts cannot run `make sdk` because the Microkit SDK
+publishes no FreeBSD archive; point `SEL4_SDK` at a cross-built SDK instead.
+
+## 1. Host packages
+
+The Makefile checks for these tools but does not install them.
+`make install` (alias `make deps`) only builds the Rust `xtask` runner.
+
+macOS:
+
+```bash
+brew install llvm lld qemu dtc libarchive zstd cmake ninja coreutils
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+```
+
+The Makefile finds Homebrew LLVM under `/opt/homebrew/opt/llvm/bin` (or
+`llvm@*`) and `ld.lld` under `/opt/homebrew/opt/lld/bin`. `bsdtar` comes from
+`libarchive`.
+
+Debian/Ubuntu:
+
+```bash
+sudo apt-get install -y clang lld llvm \
+    qemu-system-arm qemu-system-x86 \
+    device-tree-compiler libarchive-tools zstd \
+    cmake ninja-build curl
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+```
+
+This is the package set the CI jobs install (`.github/workflows/ci.yml`),
+plus `zstd`, `cmake`, and `ninja`, which `make demo-check` requires.
+
+Rust stable is enough; no extra targets are needed for the target build.
+
+## 2. Microkit SDK
+
+agentOS builds against one external seL4 Microkit **2.1.0** SDK.
+
+```bash
+make sdk
+```
+
+`make sdk` downloads
+`https://github.com/seL4/microkit/releases/download/2.1.0/microkit-sdk-2.1.0-<platform>.tar.gz`
+for your host and unpacks it to `SEL4_SDK`, which defaults to
+`$HOME/.cache/agentos/microkit-sdk-2.1.0`. It is idempotent: if
+`$SEL4_SDK/board` exists it prints the path and exits.
+
+To use an existing SDK:
+
+```bash
+export SEL4_SDK=/absolute/path/to/microkit-sdk-2.1.0
+```
+
+CI uses `SEL4_SDK=/tmp/microkit-sdk-2.1.0`; the Makefile default is the
+per-user cache above. Both are the same archive.
+
+`make setup` runs `make install`, `make sdk`, and `make demo-check` (a tool
+presence check) in one step.
+
+## 3. Boot agentOS with no guest
+
+```bash
+git clone https://github.com/jordanhubbard/agentos.git
+cd agentos
+make setup
+make build TARGET_ARCH=aarch64 GUEST_OS=none
+make test  TARGET_ARCH=aarch64 GUEST_OS=none
+```
+
+`make build` runs the root-task Makefile under
+`kernel/agentos-root-task/`, links the PD ELFs, packs them with
+`cargo xtask gen-pd-bundle` and `cargo xtask gen-image`, and writes
+`build/qemu_virt_aarch64/agentos.img`.
+
+`make test` runs `cargo xtask qemu-test --board qemu_virt_aarch64
+--guest-os none` and waits for the serial marker
+
+```
+agentOS boot complete
+```
+
+which `cc_pd`, the lowest-priority PD in the image, prints right before it
+enters its request loop. Exit status 0 means every PD in
+`kernel/agentos-root-task/src/system_desc_aarch64.c` loaded and the root task
+parked. It proves nothing about I/O: with `GUEST_OS=none` the VMM is a stub.
+
+The x86_64 path boots a reduced root-task topology and waits for
+`[rt] boot complete` with no `[rt] FAULT` line:
+
+```bash
+make test TARGET_ARCH=x86_64 GUEST_OS=none
+```
+
+To watch the boot interactively instead of asserting on it:
+
+```bash
+make run GUEST_OS=none        # serial on stdout; exit QEMU with Ctrl-A X
+```
+
+## 4. Host-only checks
+
+```bash
+make test-host
+```
+
+Runs `policy-check` (language and UI policy, `cargo fmt --check` on xtask),
+`guest-profile-check` (compiles the guest profiles and runs their host tests),
+`lint-source` (the `docs/TCB.md` invariant lint over the compiled topology),
+and `test-integration` (host-compiled C suites with seL4 IPC stubbed). It is a
+pre-filter, not a boot proof.
+
+## 5. Guest I/O proofs (Buildroot)
+
+```bash
+make test-guest-net QEMU_TEST_TIMEOUT=480
+make test-guest-blk QEMU_TEST_TIMEOUT=480
+```
+
+Both boot a small Buildroot Linux (kernel and rootfs from the libvmm example
+images, downloaded on first run into `build/qemu_virt_aarch64/`, about 36 MB
+in total; `make clean` removes them) under `guest_vmm_primary`. The guest DTB advertises only agentOS
+emulated devices: virtio-net at guest IPA `0x0A010000`, virtio-blk at
+`0x0A020000`, virtio-console at `0x0A030000`.
+
+`test-guest-net` passes when the log contains
+`emulated virtio-net: guest DRIVER_OK` and one guest frame has gone through
+the sDDF queues to `net_virt` and back. `test-guest-blk` passes when
+`emulated virtio-blk: guest DRIVER_OK` appears and one request (the kernel's
+partition scan of the `blk_virt` RAM disk) completes. Both require
+`BOARD=qemu_virt_aarch64` (the default on an AArch64 host; pass it explicitly
+on x86_64 hosts).
+
+## 6. Ubuntu initramfs proofs
+
+```bash
+make test-guest-console QEMU_TEST_TIMEOUT=480
+make test-ubuntu-virtio  QEMU_TEST_TIMEOUT=480
+```
+
+Both use the `ubuntu-e2e.toml` profile: the Ubuntu 26.04 arm64 kernel taken
+from the official desktop ISO plus a deterministic generated initramfs. On
+first run `make fetch-guest` (invoked by `make build`) downloads
+`ubuntu-26.04-desktop-arm64.iso` (about 4.2 GB) from `cdimage.ubuntu.com`
+into `${AGENTOS_ISO_DIR:-$HOME/.cache/agentos/isos}` and stages extracted
+artifacts under `build/guest-images/`.
+
+`test-guest-console` boots to the login prompt over the emulated
+virtio-console (`console=hvc0`), injects input through `cc_pd`, and requires
+the guest to echo it. `test-ubuntu-virtio` additionally attaches the ISO as
+host media owned by `virtio_blk` and requires real I/O markers for all three
+classes, including `[net_virt] TX accepted by net_pd` and
+`[blk_virt] host media`. Neither QEMU virtio device is visible to the guest.
+
+The full Casper live-filesystem proof, `make test-ubuntu-live
+QEMU_TEST_TIMEOUT=7200`, takes up to two hours under TCG and runs nightly
+(`.github/workflows/ubuntu-live-nightly.yml`), not per push.
+
+## 7. The gate
+
+```bash
+make gate
+```
+
+Runs `test-host`, the aarch64 and x86_64 `GUEST_OS=none` boots, and
+`gate-guest-io` (`test-guest-net`, `test-guest-blk`, `test-guest-console`).
+This is the command that must pass before any OS-level claim is made.
+
+## 8. Dual-guest demo
+
+```bash
+make demo-test                 # non-interactive: boot Ubuntu + FreeBSD, prove SSH, exit
+make demo                      # same gate, then keep QEMU running and print SSH commands
+```
+
+`make demo` needs an interactive terminal, 8 GB of host RAM, roughly 20 GB of
+disk, and both ISOs (Ubuntu 26.04 desktop arm64 and
+FreeBSD-15.0-RELEASE-arm64-aarch64-dvd1, about 4 GB each). It provisions a
+run-specific Ed25519 key under `build/tmp/dual-ssh/` and forwards SSH to
+`127.0.0.1:12222` (Ubuntu) and `127.0.0.1:12223` (FreeBSD). The default
+deadline is `DUAL_OS_TEST_TIMEOUT=7200` seconds. Press Enter in the `make
+demo` terminal to stop QEMU. Details and troubleshooting: `docs/demo.md`.
+
+`make demo-desktop-test` / `make demo-desktop` are the experimental Ubuntu
+desktop-over-SSH proof (`docs/desktop-demo.md`). They are not part of the OS
+claim.
+
+## 9. Reading the logs
+
+`xtask qemu-test` writes one log per run to `build/tmp/agentos-qemu-*.log`
+and puts the control socket beside it (`agentos-qemu-*.cc_pd.sock`). `make
+run` writes `build/tmp/agentos-run.log` and exposes `build/cc_pd.sock`.
+
+Set `AGENTOS_TMP_DIR=/path` to move all of these. The path is used for Unix
+sockets, so keep it short.
+
+Markers worth searching for:
+
+| Marker | Printed by | Meaning |
+|--------|------------|---------|
+| `[rt] boot complete` | root task | PD spawn finished (x86_64 gate marker) |
+| `agentOS boot complete` | `cc_pd` | lowest-priority PD reached its loop (aarch64 gate marker) |
+| `[net_virt] READY` | `net_virt` | virtualizer attached to the shared net frame |
+| `emulated virtio-net: guest DRIVER_OK` | `guest_vmm` | guest driver finished feature negotiation |
+| `[net_virt] TX accepted by net_pd` | `net_virt` | a guest frame reached the host NIC driver |
+| `[blk_virt] host media` | `blk_virt` | block virtualizer is serving real media |
+| `[rt] FAULT` | root task | a PD faulted; the x86_64 gate fails on this |
+
+`make -C tools/agentctl` builds the CLI that talks to `cc_pd` over the socket:
+
+```bash
+./tools/agentctl/agentctl --batch list-guests
+```
+
+## 10. Troubleshooting
+
+**macOS: QEMU fails to bind its socket, or the harness times out
+immediately.** macOS limits Unix socket paths to 104 bytes. A checkout under a
+deep path (for example a git worktree under `.claude/worktrees/`) exceeds it.
+Set a short temp directory:
+
+```bash
+export AGENTOS_TMP_DIR=/tmp/agentos
+```
+
+**"Microkit SDK not found at ..."** Run `make sdk`, or export `SEL4_SDK`
+pointing at a directory that contains `board/`. The cache is
+`$HOME/.cache/agentos/microkit-sdk-2.1.0` by default and
+`/tmp/microkit-sdk-2.1.0` in CI.
+
+**"Homebrew LLVM not found" on macOS.** `brew install llvm lld`. The
+Makefile does not use Apple's `clang`.
+
+**First run is slow.** The Buildroot images are small, but the Ubuntu and
+FreeBSD ISOs are about 4 GB each. They are cached in
+`${AGENTOS_ISO_DIR:-$HOME/.cache/agentos/isos}` and survive `make clean`;
+`make clean-images` removes the staged copies under `build/guest-images/`.
+
+**Timeouts.** `QEMU_TEST_TIMEOUT` (default 300 s) bounds every `xtask
+qemu-test` run. Apple Silicon runs AArch64 QEMU under TCG because HVF trips
+on seL4's memory access patterns, so use the values in `make help`: 480 s for
+the guest proofs, 3600 to 7200 s for `test-ubuntu-live`. Linux hosts use KVM
+when `/dev/kvm` exists.
+
+**Ports in use.** `make demo` needs 12222 and 12223 free; `make run` forwards
+8789.
+
+**Stale sockets or keys.** `make demo-clean` removes `build/cc_pd.sock`,
+`build/agentos-serial.sock`, `build/tmp/dual-ssh/`, and the QEMU logs; guest
+image caches are kept.
+
+**Which board.** The guest proofs only run on `qemu_virt_aarch64`. On an
+x86_64 host, `make test` defaults to the x86_64 board; pass
+`TARGET_ARCH=aarch64` (or `BOARD=qemu_virt_aarch64`) for the AArch64 image.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,62 @@
+# agentOS documentation index
+
+One line per file. **Current** documents describe the tree as it is and are
+kept in step with it. **Historical** documents record an audit, plan, or
+design at a past date; they are kept for provenance and are not maintained.
+Where a historical document is superseded, the replacement is named. Nothing
+here is deleted; do not extend a historical document, update the current one.
+
+If two documents disagree, `TCB.md` wins, then the README, then everything
+else.
+
+## Current
+
+| File | What it is |
+|------|------------|
+| [`TCB.md`](TCB.md) | **Binding.** Trusted computing base: what boots today vs. the target shape, the five I/O invariants, the museum list, the proof gate. |
+| [`QUICKSTART.md`](QUICKSTART.md) | Clone to booted QEMU image, guest I/O proofs, logs, troubleshooting. |
+| [`DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md) | Boot flow, declaring a PD, PD skeleton, contracts, notifications, adding a virtualizer/driver/profile/native agent, testing policy. |
+| [`ROADMAP.md`](ROADMAP.md) | Release map 0.2 to 1.0, dependency order, trust-baseline corrective actions, per-release acceptance evidence. |
+| [`RELEASES.md`](RELEASES.md) | Evidence-bound release protocol: plan, prepare, check, publish, verify; branch policy; evidence matrix. |
+| [`guest-profiles.md`](guest-profiles.md) | Data-driven guest personalities: TOML profile format, host/target boundary, compiler, scenarios, console expect rules. |
+| [`demo.md`](demo.md) | The dual-guest Ubuntu + FreeBSD SSH demo: `make setup`, `make demo`, ports, timing, troubleshooting. |
+| [`desktop-demo.md`](desktop-demo.md) | Experimental Ubuntu desktop-over-SSH (RFB frame) proof. Not release-qualified. |
+| [`linux-guest-baseline.md`](linux-guest-baseline.md) | Roadmap decision: pinned Debian replaces Ubuntu as the Linux integration baseline; artifact and checksum record. |
+| [`omarchy-compatibility.md`](omarchy-compatibility.md) | Compatibility ledger for official Omarchy artifacts (roadmap 0.6 input). Facts only, no support claim. |
+| [`sel4-loader-format.md`](sel4-loader-format.md) | The `agentos.img` flat image format produced by `cargo xtask gen-image` and parsed by the root task. |
+| [`freebsd-vm-guest.md`](freebsd-vm-guest.md) | FreeBSD 15.0 guest: commands are current (`make fetch-guest GUEST_OS=freebsd`, `make run GUEST_OS=freebsd`); the architecture diagram predates the current PD set (names a `freebsd_vm` PD and `controller`/`event_bus`). |
+| [`boot-guide.md`](boot-guide.md) | Prerequisites, build steps, target architectures, QEMU interfaces. Partly stale: the "Expected First-Boot Output" markers (`[controller] ... boot complete`) and the "Agent Signing" section describe PDs no longer in the image; use `QUICKSTART.md` for markers. |
+| [`presentations/agentos-systems-security/`](presentations/agentos-systems-security/README.md) | Source for the release systems/security deck (`deck.md`) and its claim ledger (`FACTS.md`); rendered by `make presentation-render`. |
+| [`defects/`](defects/) | Filed defects. `DEFECT-001` (gpu_shmem, approved exception, now museum) and `DEFECT-002` (js_runtime removal, resolved). |
+
+## Historical (superseded or point-in-time)
+
+| File | Date | What it was | Superseded by |
+|------|------|-------------|---------------|
+| [`ARCHITECTURE.md`](ARCHITECTURE.md) | April 2026 | Auto-generated PD and contract inventory ("48 PDs in the system file"). The image now boots 13 PDs. | `TCB.md`, README "Booted PD set" |
+| [`user-guide/architecture.md`](user-guide/architecture.md) | 2026 | Layered architecture diagram naming `libagent.c` and WASM agents; `libs/libagent` has been deleted. | `TCB.md`, `DEVELOPER_GUIDE.md` |
+| [`api-surface-audit.md`](api-surface-audit.md) | 2026-04-15 | Inventory of every service opcode across `userspace/servers/`, `services/`, and the root task. Many of those trees were deleted in the trust-baseline cleanup. | `TCB.md` museum list, `kernel/agentos-root-task/include/contracts/` |
+| [`consolidation-plan.md`](consolidation-plan.md) | 2026-04-15 | Plan to merge duplicate services, partially executed. | `CHANGELOG.md` Unreleased "Removed"; `ROADMAP.md` trust baseline |
+| [`REFACTORING_PLAN.md`](REFACTORING_PLAN.md) | April 2026 | Repository-wide refactoring plan from the April audit. | `PLAN.md`, `ROADMAP.md` |
+| [`VIBEOS_ANALYSIS.md`](VIBEOS_ANALYSIS.md) | April 2026 | Deep dive on the VibeOS dynamic-OS-creation API. VibeOS and the agent-facing services are museum code, not in the booted image. | `TCB.md` museum list |
+| [`os-review.md`](os-review.md) | April 2026 | External-style OS design review of v0.1.0-alpha, including the Rust SDK and the "ring" model that `TCB.md` has since rejected. | `TCB.md` |
+| [`ui-audit.md`](ui-audit.md) | 2026 | Discoverability audit of the former console dashboard. The dashboard and all in-repo UI were removed under the UI policy. | `CLAUDE.md` UI policy |
+| [`device-audit.md`](device-audit.md) | 2026-04-15 | Audit of Linux and FreeBSD VMM device handling against the OS-neutral service rule; references `kernel/freebsd-vmm/`, which no longer exists (one guest-neutral `guest_vmm.c` remains). | `TCB.md` "How I/O flows today" |
+| [`libvmm-migration-inventory.md`](libvmm-migration-inventory.md) | 2026 | Inventory of Microkit API call sites in the VMM layer, preparatory to replacing Microkit with direct seL4 syscalls (done: the root task spawns PDs itself). | `DEVELOPER_GUIDE.md` section 1 |
+| [`p0-guest-e2e-tasks.md`](p0-guest-e2e-tasks.md) | 2026 | Bring-up record of the first guest E2E gaps. Marked historical in its own header. | `demo.md`, `make demo-test` |
+| [`cc-consumer-pattern.md`](cc-consumer-pattern.md) | 2026 | How external tools talk to `cc_pd` over its socket (guest list/status/console opcodes). The opcode descriptions track `contracts/cc_contract.h`; the framing around "web UIs, mobile apps, dashboards" predates the UI policy. | `kernel/agentos-root-task/include/contracts/cc_contract.h`, `tools/agentctl` |
+| [`PRIORITY_INHERITANCE.md`](PRIORITY_INHERITANCE.md) | 2026-03-31 | Design note for priority inheritance on passive-PD PPCs under Microkit. The Microkit PPC model is no longer used; priorities are the descriptor's DAG. | `DEVELOPER_GUIDE.md` section 2, descriptor comment in `system_desc_aarch64.c` |
+
+## Top-level documents outside `docs/`
+
+| File | Status |
+|------|--------|
+| [`../README.md`](../README.md) | Current. Overview, booted PD set, quick start, proof table. |
+| [`../CLAUDE.md`](../CLAUDE.md) | Current, binding. Project constitution: TCB, language and UI policy, I/O policy, tests, tracker. |
+| [`../AGENTS.md`](../AGENTS.md) | Current, binding. Short-form rules and workflow for contributors and agents. |
+| [`../PLAN.md`](../PLAN.md) | Current. Active implementation sequencing with MAC task ids. |
+| [`../CHANGELOG.md`](../CHANGELOG.md) | Current. Release notes; Unreleased section lists known limitations. |
+| [`../DESIGN.md`](../DESIGN.md) | Vision document from March 2026 (agent identity, capabilities, vibe-coding, agent services). Its status table predates the trust-baseline audit; see the banner at its top. |
+| [`../platform/README.md`](../platform/README.md) | Platform I/O tree map. Its table still marks `net_virt` and `blk_virt` as "not in the live image"; both are booted PDs now (`TCB.md`). |
+| [`../tests/TARGET_TESTS.md`](../tests/TARGET_TESTS.md) | Current. Host tests vs. source lint vs. target proof. |
+| [`../EXTERNAL_CONTRIBUTOR_TEST.md`](../EXTERNAL_CONTRIBUTOR_TEST.md) | Historical. Artifact of a GitHub issue two-way-sync pipeline test; not documentation. |


### PR DESCRIPTION
## Summary
Documentation for the post-audit platform (13 booted PDs, net_virt and blk_virt as real PDs, honest gate).

- `README.md`: rewritten (504 -> 236 lines). What agentOS is, today-vs-target table, booted PD table with source paths, quick start, current tree, proof-level legend and status table derived from CI jobs and `docs/TCB.md`, roadmap/releases, contributing, license. Museum material (vibe-coding, libagent, CUDA/gpu_shmem, agent services) removed.
- `docs/QUICKSTART.md` (new, 261 lines): SDK and toolchain setup as the Makefile actually does it, boot with `GUEST_OS=none`, host checks, Buildroot proofs, Ubuntu proofs, `make gate`, dual-guest demo, reading logs, troubleshooting (macOS socket path limit, SDK location, first-run downloads, timeouts).
- `docs/DEVELOPER_GUIDE.md` (new, 417 lines): boot flow, declaring a PD, contracts, notifications vs IPC, adding a virtualizer or driver PD using the `net_virt` commits as the template, guest profiles, native clients (honest: nothing native attaches to a virtualizer yet), testing policy, language policy, mac.
- `docs/README.md` (new): index classifying 15 current and 13 historical docs.
- `DESIGN.md`: banner pointing at TCB.md and the README as current truth.
- CHANGELOG: Documentation entry.

Every documented command was checked against Makefile targets and `cargo xtask --help`; every path against the tree. `make test-host` passes.

Follow-up filed: MAC task_d21e0e8c (stale platform/README.md, boot-guide, freebsd-vm-guest, config.yaml comments, xtask setup advice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)