### PR TITLE
platform: prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-09-11
+
 ### Changed
 
 - `make gate` is now an honest OS-claim gate: it runs the host suite, the
@@ -16,16 +18,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The two-hour Ubuntu Casper live-media proof moved out of per-push CI into a
   scheduled `ubuntu-live-nightly.yml` workflow. It had never passed on `main`
   since it was added and turned every push red.
-- The default aarch64 image boots 11 PDs (nameserver, log_drain, serial_pd,
-  vibe_engine, virtio_blk, block_pd, net_pd, guest_vmm_primary, vm_manager,
-  cc_pd, fault_handler). The manifest previously bundled 39 ELFs, 20 of which
-  the root task never started; the descriptor also dropped controller,
-  event_bus, init_agent, agentfs, vfs_server, net_server, framebuffer_pd, and
-  usb_pd. `cc_pd` now prints the `agentOS boot complete` marker.
+- The default aarch64 image boots 13 PDs (nameserver, log_drain, serial_pd,
+  vibe_engine, virtio_blk, block_pd, net_pd, net_virt, blk_virt,
+  guest_vmm_primary, vm_manager, cc_pd, fault_handler). The v0.2.2 manifest
+  bundled 39 ELFs, 20 of which the root task never started; the descriptor
+  also dropped controller, event_bus, init_agent, agentfs, vfs_server,
+  net_server, framebuffer_pd, and usb_pd. `cc_pd` now prints the
+  `agentOS boot complete` marker.
 - `docs/TCB.md` describes what boots today separately from the target shape,
-  names `cc_pd` as the console driver, and records that the virtualizer is a
-  library inside `guest_vmm` bridging to driver PDs by IPC (invariant 2 not yet
-  held; tracked as a MAC task).
+  names `cc_pd` as the console driver, and states per invariant whether it is
+  held. Invariant 2 (the virtualizer is the only mux) is held for net and
+  block and not yet for console.
 - Host tests under `tests/platform` no longer assert by grepping source text.
   Of 95 assertions, 4 behavioral tests remain, 26 architecture invariants moved
   to `tests/platform/lint_source_invariants.c` (run by `make lint-source`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/agentOS/agentos"

--- a/libs/rust-pd/Cargo.toml
+++ b/libs/rust-pd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-pd"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "Rust Protection Domain runtime for seL4 Microkit on agentOS"
 license = "Apache-2.0"

--- a/tools/attest-verify/Cargo.toml
+++ b/tools/attest-verify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attest-verify"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]

--- a/tools/gen-abi/Cargo.toml
+++ b/tools/gen-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-abi"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]

--- a/tools/gen-ringbuf/Cargo.toml
+++ b/tools/gen-ringbuf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-ringbuf"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]

--- a/tools/gen-sdf/Cargo.toml
+++ b/tools/gen-sdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-sdf"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]

--- a/tools/make-swap-image/Cargo.toml
+++ b/tools/make-swap-image/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "make-swap-image"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]

--- a/tools/run-agent/Cargo.toml
+++ b/tools/run-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "run-agent"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "agentOS CLI — load and run a signed .wasm agent on the host using the sim layer"
 license = "Apache-2.0"

--- a/tools/sign-wasm/Cargo.toml
+++ b/tools/sign-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sign-wasm"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]

--- a/tools/trace-replay/Cargo.toml
+++ b/tools/trace-replay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trace-replay"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]

--- a/userspace/agents/init-agent/Cargo.toml
+++ b/userspace/agents/init-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-init-agent"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 [features]

--- a/userspace/sdk/Cargo.toml
+++ b/userspace/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-sdk"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "agentOS SDK - core abstractions for agent-native operating system"
 license = "Apache-2.0"

--- a/userspace/servers/capability-broker/Cargo.toml
+++ b/userspace/servers/capability-broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-capability-broker"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "Simulation model of the CapBroker PD — NOT deployed on seL4"
 

--- a/userspace/servers/event-bus/Cargo.toml
+++ b/userspace/servers/event-bus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-event-bus"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "Simulation model of the EventBus PD — NOT deployed on seL4"
 

--- a/userspace/servers/http-gateway/Cargo.toml
+++ b/userspace/servers/http-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-http-gateway"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "HTTP Gateway — hyper-based HTTP/1.1 server that dispatches requests to agentOS apps via http_svc"
 

--- a/userspace/servers/model-proxy/Cargo.toml
+++ b/userspace/servers/model-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-model-proxy"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "Model Proxy - capability-gated LLM inference service for agentOS"
 

--- a/userspace/servers/tool-registry/Cargo.toml
+++ b/userspace/servers/tool-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-tool-registry"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "Tool Registry - capability-gated tool registration and dispatch for agentOS"
 

--- a/userspace/servers/vibe-engine/Cargo.toml
+++ b/userspace/servers/vibe-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-vibe-engine"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "Vibe Engine - service hot-swap protocol for agentOS vibe-coding"
 

--- a/userspace/sim/Cargo.toml
+++ b/userspace/sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos-sim"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "agentOS WASM agent simulator — runs signed .wasm agents on the host with mock seL4 Microkit IPC"
 license = "Apache-2.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Release preparation for **v0.3.0 — Trust baseline and virtualizer tier**, per `docs/RELEASES.md` (plan -> prepare -> PR -> check -> publish).

- Workspace and crate versions 0.2.2 -> 0.3.0 (`make release-prepare RELEASE_VERSION=0.3.0 RELEASE_DATE=2026-09-11`).
- CHANGELOG: `Unreleased` promoted to `[0.3.0] - 2026-09-11`; PD count and invariant-2 status bullets corrected to the final state (13 PDs; invariant 2 held for net and block).
- Minor bump because the release adds two contracts and two PDs (`docs/RELEASES.md`: new protocols wait for a minor). The four former `v0.3:` MAC tasks were retitled `v0.4:`; `xtask release plan --bump minor` reports no open milestone tasks.

After merge: `make release-check RELEASE_VERSION=0.3.0` on main (test-host + full gate), then `make release-publish RELEASE_VERSION=0.3.0 RELEASE_AUTHORIZE=publish-v0.3.0`, then `make release-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)