### PR TITLE
test: fix app slot contract harness assertions

### DIFF
--- a/tests/contracts/app_slot_test.c
+++ b/tests/contracts/app_slot_test.c
@@ -1,8 +1,9 @@
 /*
  * app_slot_test.c — contract tests for the AppSlot PD (notification-only)
  *
- * Covered opcodes:
- *   APP_SLOT_CH_SPAWN              — notification channel to/from SpawnServer
+ * AppSlot is a passive, notification-driven PD with no IPC protected()
+ * handler.  This test verifies that the contract constants defined in
+ * app_slot_contract.h are present and have the expected values.
  *
  * Copyright (c) 2026 The agentOS Project
  * SPDX-License-Identifier: BSD-2-Clause
@@ -12,29 +13,52 @@
 #include "../../kernel/agentos-root-task/include/agentos.h"
 #include "../../kernel/agentos-root-task/include/contracts/app_slot_contract.h"
 
-/*
- * AppSlot is a notification-only PD — it has no IPC protected() handler.
- * All communication is via seL4 notifications with SpawnServer.
- * This test verifies the PD exists and its contract constants are defined.
- */
 void run_app_slot_tests(microkit_channel ch)
 {
+    (void)ch;  /* notification-only PD — no IPC channel exercised */
     TEST_SECTION("app_slot");
 
-    /*
-     * AppSlot has no IPC opcodes.  Verify contract constants are defined
-     * and consistent.
-     */
-    ASSERT_TRUE(APP_SLOT_OK == 0u,
-                "app_slot: APP_SLOT_OK is zero");
-    ASSERT_TRUE(APP_SLOT_ERR_HASH == 1u,
-                "app_slot: APP_SLOT_ERR_HASH is 1");
-    ASSERT_TRUE(APP_SLOT_ERR_TRUNCATED == 2u,
-                "app_slot: APP_SLOT_ERR_TRUNCATED is 2");
-    ASSERT_TRUE(APP_SLOT_ERR_INVAL == 3u,
-                "app_slot: APP_SLOT_ERR_INVAL is 3");
-    ASSERT_TRUE(SPAWN_HEADER_MAGIC == 0x5350574eu,
-                "app_slot: SPAWN_HEADER_MAGIC is 'SPWN'");
-    ASSERT_TRUE(sizeof(app_slot_spawn_header_t) > 0,
-                "app_slot: spawn_header_t struct has non-zero size");
+    /* APP_SLOT_OK must be zero (success). */
+    if (APP_SLOT_OK == 0u) {
+        _tf_ok("app_slot: APP_SLOT_OK == 0");
+    } else {
+        _tf_fail_point("app_slot: APP_SLOT_OK == 0", "value is not zero");
+    }
+
+    /* APP_SLOT_ERR_HASH must be 1. */
+    if (APP_SLOT_ERR_HASH == 1u) {
+        _tf_ok("app_slot: APP_SLOT_ERR_HASH == 1");
+    } else {
+        _tf_fail_point("app_slot: APP_SLOT_ERR_HASH == 1", "unexpected value");
+    }
+
+    /* APP_SLOT_ERR_TRUNCATED must be 2. */
+    if (APP_SLOT_ERR_TRUNCATED == 2u) {
+        _tf_ok("app_slot: APP_SLOT_ERR_TRUNCATED == 2");
+    } else {
+        _tf_fail_point("app_slot: APP_SLOT_ERR_TRUNCATED == 2", "unexpected value");
+    }
+
+    /* APP_SLOT_ERR_INVAL must be 3. */
+    if (APP_SLOT_ERR_INVAL == 3u) {
+        _tf_ok("app_slot: APP_SLOT_ERR_INVAL == 3");
+    } else {
+        _tf_fail_point("app_slot: APP_SLOT_ERR_INVAL == 3", "unexpected value");
+    }
+
+    /* SPAWN_HEADER_MAGIC must be 0x5350574e ("SPWN"). */
+    if (SPAWN_HEADER_MAGIC == 0x5350574eu) {
+        _tf_ok("app_slot: SPAWN_HEADER_MAGIC == 0x5350574e (\"SPWN\")");
+    } else {
+        _tf_fail_point("app_slot: SPAWN_HEADER_MAGIC == 0x5350574e (\"SPWN\")",
+                       "unexpected magic value");
+    }
+
+    /* app_slot_spawn_header_t must be a non-zero-sized struct. */
+    if (sizeof(app_slot_spawn_header_t) > 0u) {
+        _tf_ok("app_slot: spawn_header_t has non-zero size");
+    } else {
+        _tf_fail_point("app_slot: spawn_header_t has non-zero size",
+                       "struct has zero size");
+    }
 }


### PR DESCRIPTION
## Summary

- replace the undefined `ASSERT_TRUE` calls with the target TAP harness emitters
- silence the unused notification-only channel parameter
- preserve coverage for all AppSlot contract constants

## Validation

- `make test-host`
- standalone C11 syntax check with `-Wall -Wextra -Werror`